### PR TITLE
Fix "shadow" warnings. (Self pull request to check against Travis, if successful will merge to master)

### DIFF
--- a/include/G4SBSIO.hh
+++ b/include/G4SBSIO.hh
@@ -5,7 +5,6 @@
 #include "TObject.h"
 #include "THashTable.h"
 #include "G4Run.hh"
-#include "G4SystemOfUnits.hh"
 #include "G4SBSRICHoutput.hh"
 #include "G4SBSECaloutput.hh"
 #include "G4SBSTrackerOutput.hh"
@@ -107,15 +106,15 @@ public:
   void FillTree();
   void WriteTree();
   
-  void SetBeamE(double E){ gendata.Ebeam = E/GeV; }
+  void SetBeamE(double E){ gendata.Ebeam = E/CLHEP::GeV; }
   void SetBigBiteTheta(double th){ gendata.thbb = th; }
-  void SetBigBiteDist(double d){ gendata.dbb = d/m; }
+  void SetBigBiteDist(double d){ gendata.dbb = d/CLHEP::m; }
   void SetSBSTheta(double th){ gendata.thsbs = th; }
-  void SetHcalDist(double d){ gendata.dhcal = d/m; }
-  void SetHcalVOffset(double d){ gendata.voffhcal = d/m; }
-  void SetSBSDist(double d){ gendata.dsbs = d/m; }
-  void SetRICHDist(double d){ gendata.drich = d/m; }
-  void SetSBStrkrDist(double d){ gendata.dsbstrkr = d/m; }
+  void SetHcalDist(double d){ gendata.dhcal = d/CLHEP::m; }
+  void SetHcalVOffset(double d){ gendata.voffhcal = d/CLHEP::m; }
+  void SetSBSDist(double d){ gendata.dsbs = d/CLHEP::m; }
+  void SetRICHDist(double d){ gendata.drich = d/CLHEP::m; }
+  void SetSBStrkrDist(double d){ gendata.dsbstrkr = d/CLHEP::m; }
   
   void SetGlobalField(G4SBSGlobalField *gf){fGlobalField = gf; }
   

--- a/src/G4SBSDetectorConstruction.cc
+++ b/src/G4SBSDetectorConstruction.cc
@@ -1,6 +1,5 @@
 #include "G4SBSDetectorConstruction.hh"
 
-#include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 #include "G4UserLimits.hh"
 //#include "G4String.hh"
@@ -54,6 +53,9 @@
 #include <map>
 #include <algorithm>
 //#include <pair>
+
+// To supress errors with TString, system of units should be included last
+#include "G4SystemOfUnits.hh"
 
 using namespace std;
 

--- a/src/G4SBSEArmBuilder.cc
+++ b/src/G4SBSEArmBuilder.cc
@@ -44,10 +44,12 @@
 
 #include "sbstypes.hh"
 
-#include "G4SystemOfUnits.hh"
 #include "G4PhysicalConstants.hh"
 
 #include "TString.h"
+
+// To supress errors with TString, system of units should be included last
+#include "G4SystemOfUnits.hh"
 
 using namespace std;
 

--- a/src/G4SBSIO.cc
+++ b/src/G4SBSIO.cc
@@ -20,9 +20,9 @@ G4SBSIO::G4SBSIO(){
     fFile = NULL;
 
     gendata.Ebeam = 2.2;
-    gendata.thbb = 40.0*deg;
+    gendata.thbb = 40.0*CLHEP::deg;
     gendata.dbb = 1.5;
-    gendata.thsbs = 39.4*deg;
+    gendata.thsbs = 39.4*CLHEP::deg;
     gendata.dhcal = 17.0;
     gendata.voffhcal = 0.0;
     gendata.dsbs = 1.6;

--- a/src/G4SBSPrimaryGeneratorAction.cc
+++ b/src/G4SBSPrimaryGeneratorAction.cc
@@ -59,7 +59,7 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   G4String particleName;
   G4ParticleDefinition* particle;
 
-  ev_t evdata;
+  //ev_t evdata;
 
   //G4SBSPythiaOutput Primaries;
   
@@ -75,8 +75,8 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
   int ntries_run = RunAction->GetNtries();
   RunAction->SetNtries( ntries_run + ntries );
 
-  evdata = sbsgen->GetEventData();
-  fIO->SetEventData(evdata);
+  //evdata = sbsgen->GetEventData();
+  fIO->SetEventData(sbsgen->GetEventData());
 
   if( sbsgen->GetKine() == kPYTHIA6 ){ //PYTHIA6 event:
     G4SBSPythiaOutput Primaries = sbsgen->GetPythiaEvent();

--- a/src/G4SBSRunData.cc
+++ b/src/G4SBSRunData.cc
@@ -51,8 +51,7 @@ void G4SBSRunData::Print(Option_t *) const {
     printf("Generator   = %s\n", fGenName);
 
     printf("Field maps:\n");
-    unsigned int i;
-    for( i = 0; i < fMagData.size(); i++ ){
+    for( unsigned int i = 0; i < fMagData.size(); i++ ){
 	printf("\t%s\n", fMagData[i].filename);
 	printf("\t%s\n", fMagData[i].hashsum);
 	printf("\t%s\n\n", fMagData[i].timestamp.AsString("ls"));


### PR DESCRIPTION
The most annoying warning was with the seconds 's' in G4SystemOfUnits and
an internal 's' in a TString.  The quick fix was to move the inclusion of
G4SystemOfUnits to the end in the source files, and to remove it
entirely from G4SBSIO (relying now on using the full namespace of CLHEP, i.e.,
CLHEP::GeV).