### PR TITLE
Better check for built-in versus custom CLHEP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,15 +66,13 @@ include(${Geant4_USE_FILE})
 #include_directories(${PROJECT_SOURCE_DIR}/include)
 
 #check for absence of GEANT4's built-in CLHEP and use of a custom CLHEP:
-set(SYSTEM_CLHEP OFF)
+#set(SYSTEM_CLHEP OFF)
 
-if( NOT EXISTS ${Geant4_INCLUDE_DIR}/CLHEP ) 
-    set(SYSTEM_CLHEP ON)
-endif()
+#if( NOT EXISTS ${Geant4_INCLUDE_DIR}/CLHEP ) 
+#    set(SYSTEM_CLHEP ON)
+#endif()
 
-if( ${SYSTEM_CLHEP} )
-    find_package(CLHEP REQUIRED)
-endif()
+
 
 #ROOT path
 # commented out the following line so that this procedure will evolve with ROOT:
@@ -90,9 +88,9 @@ include(${ROOT_USE_FILE})
 
 include_directories(${PROJECT_SOURCE_DIR}/include ${ROOT_INCLUDE_DIR} ${Geant4_INCLUDE_DIR} ${CLHEP_INCLUDE_DIR} ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/src/dss2007 ${CMAKE_CURRENT_BINARY_DIR}/include)
 
-if( ${SYSTEM_CLHEP} )
-    include_directories(${CLHEP_INCLUDE_DIR})
-endif()
+
+
+
 
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project
@@ -128,7 +126,13 @@ add_library(g4sbsroot SHARED ${libsources} ${libheaders} G__g4sbsroot.cxx)
 target_link_libraries(g4sbs g4sbsroot ${Geant4_LIBRARIES} ${ROOT_LIBRARIES} sbscteq )
 target_link_libraries(g4sbsroot ${ROOT_LIBRARIES} )
 
-if( ${SYSTEM_CLHEP} )
+#if( ${SYSTEM_CLHEP} )
+# check for absence of GEANT4's built-in CLHEP. If it isn't there,
+# we have to find it:
+if( NOT ${Geant4_builtin_clhep_FOUND})
+    find_package(CLHEP REQUIRED)
+
+    include_directories(${CLHEP_INCLUDE_DIR})
     target_link_libraries(g4sbs CLHEP::CLHEP)
     target_link_libraries(g4sbsroot CLHEP::CLHEP)
 endif()


### PR DESCRIPTION
Use existing cmake variables set by find_package(Geant4) to check for built-in versus custom CLHEP