### PR TITLE
Updates to SIMC generator:

### DIFF
--- a/include/G4SBSSIMCOutput.hh
+++ b/include/G4SBSSIMCOutput.hh
@@ -11,6 +11,8 @@ public:
   void Clear();
   void ConvertToTreeUnits();
   
+  int fnucl; // Final-state nucleon type: 1 = proton, 0 = neutron
+
   double sigma, Weight;
   double Q2; //negative of virtual photon invariant mass:
   double xbj; //Usual Bjorken x variable;

--- a/include/sbstypes.hh
+++ b/include/sbstypes.hh
@@ -14,7 +14,7 @@
 namespace G4SBS { 
   // particle type definitions (matches the GEANT4 standard) 
   enum Nucl_t   { kProton, kNeutron };
-  enum Hadron_t { kPiPlus, kPiMinus, kPi0, kKPlus, kKMinus, kP, kPbar}; //Hadron types for SIDIS event generator
+  enum Hadron_t { kPiPlus, kPiMinus, kPi0, kKPlus, kKMinus, kP, kPbar, kN}; //Hadron types for SIDIS & SIMC event generator
   // target type; include fictional neutron target
   enum Targ_t   { kH2, kD2, kLH2, kLD2, k3He, kNeutTarg, kCfoil, kOptics };
   // kinematic type 

--- a/include/simc_tree.h
+++ b/include/simc_tree.h
@@ -1,8 +1,8 @@
 //////////////////////////////////////////////////////////
 // This class has been automatically generated on
-// Thu Jun 30 12:18:50 2022 by ROOT version 6.24/06
+// Tue Apr 18 17:03:32 2023 by ROOT version 6.20/04
 // from TTree h10/h10
-// found on file: elastic_calo.root
+// found on file: temp1.root
 //////////////////////////////////////////////////////////
 
 #ifndef simc_tree_h
@@ -11,9 +11,6 @@
 #include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-
-using namespace std;
-// Fixed size dimensions of array or collections stored in the TTree if any.
 
 // Header file for the classes stored in the TTree if any.
 
@@ -81,6 +78,9 @@ public :
    Float_t         ph_e;
    Float_t         th_p;
    Float_t         ph_p;
+   Float_t         vxi;
+   Float_t         vyi;
+   Float_t         vzi;
 
    // List of branches
    TBranch        *b_hsdelta;   //!
@@ -139,6 +139,9 @@ public :
    TBranch        *b_ph_e;   //!
    TBranch        *b_th_p;   //!
    TBranch        *b_ph_p;   //!
+   TBranch        *b_vxi;   //!
+   TBranch        *b_vyi;   //!
+   TBranch        *b_vzi;   //!
 
    simc_tree(TTree *tree=0);
    virtual ~simc_tree();
@@ -159,9 +162,9 @@ simc_tree::simc_tree(TTree *tree) : fChain(0)
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
    if (tree == 0) {
-      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("elastic_calo.root");
+      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("temp1.root");
       if (!f || !f->IsOpen()) {
-         f = new TFile("elastic_calo.root");
+         f = new TFile("temp1.root");
       }
       f->GetObject("h10",tree);
 
@@ -266,6 +269,9 @@ void simc_tree::Init(TTree *tree)
    fChain->SetBranchAddress("ph_e", &ph_e, &b_ph_e);
    fChain->SetBranchAddress("th_p", &th_p, &b_th_p);
    fChain->SetBranchAddress("ph_p", &ph_p, &b_ph_p);
+   fChain->SetBranchAddress("vxi", &vxi, &b_vxi);
+   fChain->SetBranchAddress("vyi", &vyi, &b_vyi);
+   fChain->SetBranchAddress("vzi", &vzi, &b_vzi);
    Notify();
 }
 

--- a/src/G4SBSEventGen.cc
+++ b/src/G4SBSEventGen.cc
@@ -2563,9 +2563,11 @@ bool G4SBSEventGen::GenerateSIMC(){
   fSIMCEvent.py_n = fSIMCTree->p_p*fSIMCTree->uy_p;
   fSIMCEvent.pz_n = fSIMCTree->p_p*fSIMCTree->uz_p;
   
-  fSIMCEvent.vx = fVert.x();
-  fSIMCEvent.vy = fVert.y();
-  fSIMCEvent.vz = fVert.z();
+  fSIMCEvent.vx = fSIMCTree->vxi*cm;
+  fSIMCEvent.vy = fSIMCTree->vyi*cm;
+  fSIMCEvent.vz = fSIMCTree->vzi*cm;
+
+  fVert.set(fSIMCEvent.vx, fSIMCEvent.vy, fSIMCEvent.vz);
   
   fElectronP = G4ThreeVector(fSIMCEvent.px_e, fSIMCEvent.py_e, fSIMCEvent.pz_e);
   fElectronP.rotateZ(-TMath::PiOver2());

--- a/src/G4SBSIO.cc
+++ b/src/G4SBSIO.cc
@@ -812,6 +812,7 @@ void G4SBSIO::BranchSIMC(){
   
   fTree->Branch("simc.Ebeam",&(SIMCprimaries.Ebeam),"simc.Ebeam/D");
   
+  fTree->Branch("simc.fnucl",&(SIMCprimaries.fnucl),"simc.fnucl/I");
   fTree->Branch("simc.p_e",&(SIMCprimaries.p_e),"simc.p_e/D");
   fTree->Branch("simc.theta_e",&(SIMCprimaries.theta_e),"simc.theta_e/D");
   fTree->Branch("simc.phi_e",&(SIMCprimaries.phi_e),"simc.phi_e/D");

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -277,7 +277,7 @@ G4SBSMessenger::G4SBSMessenger(){
   GunParticleCmd->SetParameterName("ptype", false );
 
   HadrCmd = new G4UIcmdWithAString("/g4sbs/hadron",this);
-  HadrCmd->SetGuidance("Hadron type h for SIDIS N(e,e'h)X generator: pi+/pi-/K+/K-/p/pbar possible");
+  HadrCmd->SetGuidance("Hadron type h for SIDIS N(e,e'h)X generator: pi+/pi-/K+/K-/p/pbar possible. Also, Nucleon type N for SIMC A(e,e'N) generator: p/n are possible.");
   HadrCmd->SetParameterName("hadrontype", false );
 
   RejectionSamplingCmd = new G4UIcommand("/g4sbs/rejectionsampling",this);
@@ -1345,6 +1345,10 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
     } 
     if( newValue.compareTo("pbar") == 0 ){
       fevgen->SetHadronType( G4SBS::kPbar );
+      validcmd = true;
+    }
+    if( newValue.compareTo("n") == 0 ){
+      fevgen->SetHadronType( G4SBS::kN );
       validcmd = true;
     }
 

--- a/src/G4SBSPrimaryGeneratorAction.cc
+++ b/src/G4SBSPrimaryGeneratorAction.cc
@@ -114,7 +114,21 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     
     particleGun->GeneratePrimaryVertex(anEvent);
     
-    particle = particleTable->FindParticle(particleName="proton");
+    bool invalid_hadron = true;
+    switch(sbsgen->GetHadronType()) {
+    case G4SBS::kP:
+      particle = particleTable->FindParticle(particleName="proton");
+      invalid_hadron = false;
+      break;
+    case G4SBS::kN:
+      particle = particleTable->FindParticle(particleName="neutron");
+      invalid_hadron = false;
+      break;
+    }
+    if (invalid_hadron) {
+      fprintf(stderr, "%s: %s line %d - Error: Given Hadron type not valid for SIMC generator. \n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
+      exit(1);
+    }
     particleGun->SetParticleDefinition(particle);
     particleGun->SetParticleMomentumDirection( sbsgen->GetNucleonP().unit() );
     particleGun->SetParticleEnergy(sbsgen->GetNucleonE()-particle->GetPDGMass());
@@ -345,6 +359,9 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
     case G4SBS::kPbar:
       particle = particleTable->FindParticle(particleName="anti_proton");
       break;
+    case G4SBS::kN:
+      fprintf(stderr, "%s: %s line %d - Error: Given hadron type is not valid for SIDIS/Wiser generator.\n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
+      exit(1);
     default:
       particle = particleTable->FindParticle(particleName="pi+");
       break;

--- a/src/G4SBSPrimaryGeneratorAction.cc
+++ b/src/G4SBSPrimaryGeneratorAction.cc
@@ -126,7 +126,7 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       break;
     }
     if (invalid_hadron) {
-      fprintf(stderr, "%s: %s line %d - Error: Given Hadron type not valid for SIMC generator. \n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
+      fprintf(stderr, "%s: %s line %d - Error: Given Hadron type not valid for SIMC generator. Check /g4sbs/hadron flag. \n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
       exit(1);
     }
     particleGun->SetParticleDefinition(particle);
@@ -360,7 +360,7 @@ void G4SBSPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
       particle = particleTable->FindParticle(particleName="anti_proton");
       break;
     case G4SBS::kN:
-      fprintf(stderr, "%s: %s line %d - Error: Given hadron type is not valid for SIDIS/Wiser generator.\n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
+      fprintf(stderr, "%s: %s line %d - Error: Given hadron type is not valid for SIDIS/Wiser generator. Check /g4sbs/hadron flag.\n", __PRETTY_FUNCTION__, __FILE__, __LINE__);
       exit(1);
     default:
       particle = particleTable->FindParticle(particleName="pi+");

--- a/src/G4SBSSIMCOutput.cc
+++ b/src/G4SBSSIMCOutput.cc
@@ -11,6 +11,8 @@ G4SBSSIMCOutput::~G4SBSSIMCOutput(){
 }
 
 void G4SBSSIMCOutput::Clear(){
+  fnucl = 0;
+
   sigma = 0.0;
   Weight = 0.0;
   Q2 = 0.0;


### PR DESCRIPTION
List of major updates:
1. Added machinery to be able to tell g4sbs the type of final state nucleon in SIMC generated events via `.mac` file using `/g4sbs/hadron` flag. Take a look at the g4sbs documentation page for more info.
2. Existing SIMC generator was overwriting the vertex co-ordinates of SIMC generated events by the default values from g4sbs. Added necessary machinery to fix that. 
3. Added a few important output tree branches specific to SIMC generator. 