### PR TITLE
List of changes:

### DIFF
--- a/include/G4SBSIO.hh
+++ b/include/G4SBSIO.hh
@@ -30,7 +30,7 @@ class G4SBSGlobalField;
 
 //These aren't really "event"-level quantities, as they are constants describing the setup, and should be stored in the "rundata" object.
 typedef struct {
-  Double_t thbb, thsbs, dbb, dsbs, dhcal,voffhcal, hoffhcal, drich, dsbstrkr, sbstrkrpitch, dlac, vofflac, hofflac, Ebeam;
+  Double_t thbb, thsbs, dbb, dsbs, dhcal,voffhcal, hoffhcal, drich, dsbstrkr, sbstrkrpitch, dlac, vofflac, hofflac, Ebeam, Ibeam;
 } gen_t;
 
 
@@ -131,6 +131,7 @@ public:
   void WriteTree();
   
   void SetBeamE(double E){ gendata.Ebeam = E/CLHEP::GeV; }
+  void SetBeamCur(double cur){ gendata.Ibeam = cur; }
   void SetBigBiteTheta(double th){ gendata.thbb = th; }
   void SetBigBiteDist(double d){ gendata.dbb = d/CLHEP::m; }
   void SetSBSTheta(double th){ gendata.thsbs = th; }

--- a/include/G4SBSRunData.hh
+++ b/include/G4SBSRunData.hh
@@ -45,6 +45,7 @@ public:
   const char *GetExpType(){ return fExpType; }
 
   void SetBeamE(double E){ fBeamE = E; }
+  void SetBeamCur(double cur){ fBeamCur = cur; }
   void SetSeed(unsigned int seed){ fSeed = seed; }
 
   void SetNormalization( double N ){ fNormalization = N; }
@@ -64,6 +65,8 @@ public:
   void SetRICHdist( double d ){ fRICHdist = d; }
   void SetSBSTrackerDist( double d ){ fSBSTrackerdist = d; }
   void SetSBSTrackerPitch( double a ){ fSBSTrackerPitch = a; }
+
+  void SetFileName( TString fname ){ fFileName = fname; }
   
   void CalcNormalization();
   
@@ -98,6 +101,7 @@ public:
   long int fNtries;
   unsigned int  fSeed;
   double fBeamE; //GeV
+  double fBeamCur; //muA
   double fNormalization; //Normalization constant to convert observed counts to a rate. This accounts for efficiency of Monte Carlo generation, phase space volume, luminosity, etc
   double fGenVol; //Phase space generation volume; process-dependent;
   double fLuminosity; //Hz/cm^2
@@ -124,6 +128,8 @@ public:
   char fRunPath[__RUNSTR_LEN];
 
   TString fMacroPath; //Store the GEANT4 UI manager's macro search path to locate macros that aren't in current working directory
+  TString fFileName;
+
   G4SBSTextFile              fMacro;
   G4SBSTextFile   fPreInitMacro; //PreInit Commands
   std::vector<G4SBSTextFile> fExternalMacros; ///< External macros called by

--- a/include/simc_tree.h
+++ b/include/simc_tree.h
@@ -1,8 +1,8 @@
 //////////////////////////////////////////////////////////
 // This class has been automatically generated on
-// Tue Apr 18 17:03:32 2023 by ROOT version 6.20/04
+// Wed May 10 13:47:40 2023 by ROOT version 6.20/04
 // from TTree h10/h10
-// found on file: temp1.root
+// found on file: example_deen_GMn_SBS4.root
 //////////////////////////////////////////////////////////
 
 #ifndef simc_tree_h
@@ -81,6 +81,7 @@ public :
    Float_t         vxi;
    Float_t         vyi;
    Float_t         vzi;
+   Float_t         ebeam;
 
    // List of branches
    TBranch        *b_hsdelta;   //!
@@ -142,6 +143,7 @@ public :
    TBranch        *b_vxi;   //!
    TBranch        *b_vyi;   //!
    TBranch        *b_vzi;   //!
+   TBranch        *b_ebeam;   //!
 
    simc_tree(TTree *tree=0);
    virtual ~simc_tree();
@@ -162,9 +164,9 @@ simc_tree::simc_tree(TTree *tree) : fChain(0)
 // if parameter tree is not specified (or zero), connect the file
 // used to generate this class and read the Tree.
    if (tree == 0) {
-      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("temp1.root");
+      TFile *f = (TFile*)gROOT->GetListOfFiles()->FindObject("example_deen_GMn_SBS4.root");
       if (!f || !f->IsOpen()) {
-         f = new TFile("temp1.root");
+         f = new TFile("example_deen_GMn_SBS4.root");
       }
       f->GetObject("h10",tree);
 
@@ -272,6 +274,7 @@ void simc_tree::Init(TTree *tree)
    fChain->SetBranchAddress("vxi", &vxi, &b_vxi);
    fChain->SetBranchAddress("vyi", &vyi, &b_vyi);
    fChain->SetBranchAddress("vzi", &vzi, &b_vzi);
+   fChain->SetBranchAddress("ebeam", &ebeam, &b_ebeam);
    Notify();
 }
 

--- a/src/G4SBSEventGen.cc
+++ b/src/G4SBSEventGen.cc
@@ -2547,7 +2547,7 @@ bool G4SBSEventGen::GenerateSIMC(){
   fSIMCEvent.W = fSIMCTree->W;
   fSIMCEvent.epsilon = fSIMCTree->epsilon;
   
-  fSIMCEvent.Ebeam = fBeamE;
+  fSIMCEvent.Ebeam = fSIMCTree->ebeam/MeV;
   
   fSIMCEvent.p_e = fSIMCTree->p_e;
   fSIMCEvent.theta_e = fSIMCTree->th_e;

--- a/src/G4SBSIO.cc
+++ b/src/G4SBSIO.cc
@@ -34,6 +34,7 @@ G4SBSIO::G4SBSIO(){
   //Easiest (but not necessarily best?) way is to store a pointer to G4SBSIO as a data member of G4SBSDetectorConstruction so they can
   //directly talk to each other?
   gendata.Ebeam = 2.2;
+  gendata.Ibeam = 1.0;
   gendata.thbb = 40.0*CLHEP::deg;
   gendata.dbb = 1.5;
   gendata.thsbs = 39.4*CLHEP::deg;

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -1084,6 +1084,7 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
 
   if( cmd == fileCmd ){
     fIO->SetFilename(newValue.data());
+    G4SBSRun::GetRun()->GetData()->SetFileName(newValue);
   }
 
   if( cmd == sigfileCmd ){
@@ -1716,6 +1717,7 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
     G4double v = beamcurCmd->GetNewDoubleValue(newValue);
     printf("Setting beam current to %f uA\n", v/microampere);
     fevgen->SetBeamCur(v);
+    fIO->SetBeamCur(v/microampere);
     fevgen->SetInitialized(false);
   }
   if( cmd == runtimeCmd ){

--- a/src/G4SBSRunAction.cc
+++ b/src/G4SBSRunAction.cc
@@ -38,6 +38,7 @@ void G4SBSRunAction::BeginOfRunAction(const G4Run* aRun)
   
   gen_t gendata = fIO->GetGenData();
   rmrundata->SetBeamE( gendata.Ebeam );
+  rmrundata->SetBeamCur( gendata.Ibeam );
   rmrundata->SetBBtheta( gendata.thbb );
   rmrundata->SetBBdist( gendata.dbb );
   rmrundata->SetSBStheta( gendata.thsbs );
@@ -54,7 +55,7 @@ void G4SBSRunAction::BeginOfRunAction(const G4Run* aRun)
 
   //some of these are redundant with the behavior of G4SBSMessenger commands;
   
-  rmrundata->Print();
+  //rmrundata->Print();
 
 }
 
@@ -74,6 +75,7 @@ void G4SBSRunAction::EndOfRunAction(const G4Run* aRun)
   G4SBSRunData *rmrundata = G4SBSRun::GetRun()->GetData();
   
   rmrundata->CalcNormalization();
+  rmrundata->Print();
   
   fIO->WriteTree();
 }

--- a/src/G4SBSRunData.cc
+++ b/src/G4SBSRunData.cc
@@ -19,6 +19,7 @@ G4SBSRunData::G4SBSRunData(){
     fNthrown = -1;
     fNtries = -1;
     fBeamE   = -1e9;
+    fBeamCur   = -1e9;
     fExpType[0]  = '\0';
     fGenName[0]  = '\0';
     fGitInfo[0]  = '\0';
@@ -33,6 +34,7 @@ void G4SBSRunData::Init(){
     fNthrown = 0;
     fNtries = 0;
     fBeamE   = 0;
+    fBeamCur   = 0;
     fNormalization = 1.0;
     fGenVol = 4.0*pi;
     fLuminosity = 0.0;
@@ -46,6 +48,7 @@ void G4SBSRunData::Init(){
     fSBSTrackerdist = 4.5*meter;
     fSBSTrackerPitch = 0.0*degree;
     
+    fFileName = "";
     strcpy(fExpType, "default");
     strcpy(fGenName, "default");
     strcpy(fGitInfo, gGitInfoStr);
@@ -71,6 +74,8 @@ void G4SBSRunData::Print() const {
    sprintf(msg,"N_tries,%ld",fNtries);
    line.push_back(msg);
    sprintf(msg,"Beam_Energy_GeV,%f",fBeamE);
+   line.push_back(msg);
+   sprintf(msg,"Beam_Current_muA,%f",fBeamCur);
    line.push_back(msg);
    sprintf(msg,"Experiment,%s",fExpType);
    line.push_back(msg);
@@ -105,10 +110,14 @@ void G4SBSRunData::Print() const {
 
    const int NL = line.size(); 
 
+   // constructing the name of resulting CSV file
+   TString csvtemp = fFileName;
+   csvtemp.ReplaceAll(".root", ".csv");
+
    std::ofstream outfile;
-   outfile.open("run-data.csv"); 
+   outfile.open(csvtemp.Data()); 
    if( outfile.fail() ){
-      std::cout << "[G4SBSRunData::Print]: Cannot open the file: run-data.csv" << std::endl;
+     std::cout << "[G4SBSRunData::Print]: Cannot open the file: " << csvtemp << std::endl;
    }else{
       for(int i=0;i<NL;i++) outfile << line[i] << std::endl;
       outfile.close();
@@ -123,6 +132,7 @@ void G4SBSRunData::Print(Option_t *) const {
     printf("N generated = %ld\n", fNthrown);
     printf("N tries     = %ld\n", fNtries);
     printf("Beam Energy = %f GeV\n", fBeamE);
+    printf("Beam Current = %f muA\n", fBeamCur);
     printf("Experiment  = %s\n", fExpType);
     printf("Generator   = %s\n", fGenName);
     printf("Normalization = %8.5g\n", fNormalization);


### PR DESCRIPTION
1. Added method to get beam energy (corrected for loss) from SIMC tree instead of using the default from g4sbs.
2. Modified the name of `run-data.csv` file such that it mimics the name of the output ROOT file (with the path).
     - This will make sure the content of these files don't get over-written while we run multiple jobs from a single directory.
     - These files will get generated to the same directory output ROOT files are being generated.
3. Added beam current information to the output csv file.

NOTE: Addition of new attributes were inevitable to achieve the above mentioned (2 & 3) changes, which will make the G4SBSRunData objects of any old g4sbs ROOT file binary incompatible.