### PR TITLE
Fixed a bug in writing out SIMC epsilon variable..

### DIFF
--- a/src/G4SBSIO.cc
+++ b/src/G4SBSIO.cc
@@ -809,7 +809,7 @@ void G4SBSIO::BranchSIMC(){
   fTree->Branch("simc.xbj",&(SIMCprimaries.xbj),"simc.xbj/D");
   fTree->Branch("simc.nu",&(SIMCprimaries.nu),"simc.nu/D");
   fTree->Branch("simc.W",&(SIMCprimaries.W),"simc.W/D");
-  fTree->Branch("simc.epsilon",&(SIMCprimaries.xbj),"simc.epsilon/D");
+  fTree->Branch("simc.epsilon",&(SIMCprimaries.epsilon),"simc.epsilon/D");
   
   fTree->Branch("simc.Ebeam",&(SIMCprimaries.Ebeam),"simc.Ebeam/D");
   


### PR DESCRIPTION
The epsilon variable in the SIMC output tree was writing out xbj variable!