### PR TITLE
Add g4sbs/hcalangoffset

### DIFF
--- a/include/G4SBSHArmBuilder.hh
+++ b/include/G4SBSHArmBuilder.hh
@@ -17,6 +17,7 @@ public:
   void SetHCALDist(double a){ fHCALdist= a;   }
   void SetHCALVOffset(double a){ fHCALvertical_offset = a; }
   void SetHCALHOffset(double a){ fHCALhorizontal_offset = a; }
+  void SetHCALAngOffset(double a){ fHCALangular_offset = a; }
   void Set48D48Dist(double a){ f48D48dist = a; }
   void SetLACDist( double a ){ fLACdist = a; }
   void SetLACVOffset( double a ){ fLACvertical_offset = a; }
@@ -66,6 +67,7 @@ public:
   double fHCALdist;
   double fHCALvertical_offset;  // Vertical offset (from center) of HCAL
   double fHCALhorizontal_offset; // Horizontal offset (from SBS center line) of HCAL (by convention, +X is toward smaller angle)
+  double fHCALangular_offset; // Angular offset of HCAL wrt exit beamline (+ = away from beamline).
   double fRICHdist; //Distance from target to RICH entry window (in horizontal plane)
   double fRICHvertical_offset; //Vertical offset (from center)
   double fRICHhorizontal_offset; //Horizontal offset (from SBS center line, + = toward beamline).

--- a/include/G4SBSIO.hh
+++ b/include/G4SBSIO.hh
@@ -30,7 +30,7 @@ class G4SBSGlobalField;
 
 //These aren't really "event"-level quantities, as they are constants describing the setup, and should be stored in the "rundata" object.
 typedef struct {
-  Double_t thbb, thsbs, dbb, dsbs, dhcal,voffhcal, hoffhcal, drich, dsbstrkr, sbstrkrpitch, dlac, vofflac, hofflac, Ebeam, Ibeam;
+  Double_t thbb, thsbs, dbb, dsbs, dhcal, voffhcal, hoffhcal, angoffhcal, drich, dsbstrkr, sbstrkrpitch, dlac, vofflac, hofflac, Ebeam, Ibeam;
 } gen_t;
 
 
@@ -138,6 +138,7 @@ public:
   void SetHcalDist(double d){ gendata.dhcal = d/CLHEP::m; }
   void SetHcalVOffset(double d){ gendata.voffhcal = d/CLHEP::m; }
   void SetHcalHOffset(double d){ gendata.hoffhcal = d/CLHEP::m; }
+  void SetHcalAngOffset(double th){ gendata.angoffhcal = th; }
   void SetLACDist( double d){ gendata.dlac = d/CLHEP::m; }
   void SetLACVOffset( double d ){ gendata.vofflac = d/CLHEP::m; }
   void SetLACHOffset( double d ){ gendata.hofflac = d/CLHEP::m; }

--- a/include/G4SBSMessenger.hh
+++ b/include/G4SBSMessenger.hh
@@ -125,6 +125,7 @@ private:
   G4UIcmdWithADoubleAndUnit *hcaldistCmd;
   G4UIcmdWithADoubleAndUnit *hcalvoffsetCmd;
   G4UIcmdWithADoubleAndUnit *hcalhoffsetCmd;
+  G4UIcmdWithADoubleAndUnit *hcalangoffsetCmd;
 
   G4UIcmdWithABool *CDetReadyCmd;   //Cerenkov
 

--- a/src/G4SBSHArmBuilder.cc
+++ b/src/G4SBSHArmBuilder.cc
@@ -60,6 +60,7 @@ G4SBSHArmBuilder::G4SBSHArmBuilder(G4SBSDetectorConstruction *dc):G4SBSComponent
   fLACdist   = 14.0*m;
   fHCALvertical_offset = 0.0*cm;
   fHCALhorizontal_offset = 0.0*cm;
+  fHCALangular_offset = 0.0*deg;
 
   fLACvertical_offset = 0.0*cm;
   fLAChorizontal_offset = 0.0*cm;
@@ -1217,13 +1218,13 @@ void G4SBSHArmBuilder::MakeHCALV2( G4LogicalVolume *motherlog,
 
   // Specify the distance from entrance to HCAL to center of target
   G4double dist_HCalRadius = fHCALdist + dim_HCALZ/2.0;
-  G4double dist_HCALX = -dist_HCalRadius*sin(f48D48ang);
+  G4double dist_HCALX = -dist_HCalRadius*sin(f48D48ang+fHCALangular_offset);
   G4double dist_HCALY = VerticalOffset;
-  G4double dist_HCALZ = dist_HCalRadius*cos(f48D48ang);
+  G4double dist_HCALZ = dist_HCalRadius*cos(f48D48ang+fHCALangular_offset);
 
   // Specify the rotation matrix for this HCAL
   G4RotationMatrix *rot_HCAL= new G4RotationMatrix;
-  rot_HCAL->rotateY(f48D48ang);
+  rot_HCAL->rotateY(f48D48ang+fHCALangular_offset);
 
   // Define the solid for the module container and "CAN"
   G4Box *sol_Module = new G4Box("sol_Module",

--- a/src/G4SBSIO.cc
+++ b/src/G4SBSIO.cc
@@ -841,6 +841,7 @@ void G4SBSIO::UpdateGenDataFromDetCon(){ //Go with whatever is in fdetcon as of 
   gendata.dhcal = fdetcon->fHArmBuilder->fHCALdist/CLHEP::m;
   gendata.voffhcal = fdetcon->fHArmBuilder->fHCALvertical_offset/CLHEP::m;
   gendata.hoffhcal = fdetcon->fHArmBuilder->fHCALhorizontal_offset/CLHEP::m;
+  gendata.angoffhcal = fdetcon->fHArmBuilder->fHCALangular_offset;
   gendata.dlac = fdetcon->fHArmBuilder->fLACdist/CLHEP::m;
   gendata.vofflac = fdetcon->fHArmBuilder->fLACvertical_offset/CLHEP::m;
   gendata.hofflac = fdetcon->fHArmBuilder->fLAChorizontal_offset/CLHEP::m;

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -472,6 +472,10 @@ G4SBSMessenger::G4SBSMessenger(){
   hcalhoffsetCmd->SetGuidance("HCAL horizontal offset relative to SBS center line (+ = TOWARD beam line)");
   hcalhoffsetCmd->SetParameterName("dist", false);
 
+  hcalangoffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/hcalangoffset",this);
+  hcalangoffsetCmd->SetGuidance("HCAL angular offset relative to exit beamline (+ = away from beamline)");
+  hcalangoffsetCmd->SetParameterName("angle", false);
+
   CDetReadyCmd = new G4UIcmdWithABool("/g4sbs/cdetready",this);
   CDetReadyCmd->SetGuidance("Will CDet be ready or not for the experiment");
   CDetReadyCmd->SetParameterName("dist", false);
@@ -1947,6 +1951,13 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
     fdetcon->fHArmBuilder->SetHCALHOffset(v);
     //fevgen->SetHCALDist(v);
     fIO->SetHcalHOffset(v);
+  }
+
+  if( cmd == hcalangoffsetCmd ){
+    G4double v = hcalangoffsetCmd->GetNewDoubleValue(newValue);
+    fdetcon->fHArmBuilder->SetHCALAngOffset(v);
+    //fevgen->SetHCALDist(v);
+    fIO->SetHcalAngOffset(v);
   }
 
   if( cmd == CDetReadyCmd ){


### PR DESCRIPTION
Added option to include small angular HCAL offset with respect to 48D48 angle (set by g4sbs/sbsang) in degrees. + = away from beamline, consistent with g4sbs/sbsang. Default value set safely to 0.0 degrees. Does not affect any other dependencies on the angle set by g4sbs/sbsang. 

New option: g4sbs/hcalangoffset <degrees>

Useable for GMn 8/9 where HCal angle is slightly different (0.5 deg) than 48D48 angle. See attached for simple QA.

Depending on application, it may be preferable to pass an angular offset to the 48D48 magnet instead of HCal. This would entail a relatively simple change to the pull request.

[G4SBS_ HCAL angle offset added.pdf](https://github.com/JeffersonLab/g4sbs/files/13220648/G4SBS_.HCAL.angle.offset.added.pdf)