### PR TITLE
Andrew's latest updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,9 @@ if(INSTALL_SBS_FIELD_MAPS)
   message("Downloading GEN-RP field map from Bogdan, New Year's Day 2024")
   file(DOWNLOAD https://hallaweb.jlab.org/12GeV/SuperBigBite/downloads/GEn-RP-SBS_field.table ${CMAKE_CURRENT_BINARY_DIR}/GEn-RP-SBS_field.table SHOW_PROGRESS)	
 
+  message("Downloading GEN-RP field map in g4sbs-friendly coordinate system")
+  file(DOWNLOAD https://hallaweb.jlab.org/12GeV/SuperBigBite/downloads/GENRP_fieldmap_g4sbs_friendly_coordinate_system.table ${CMAKE_CURRENT_BINARY_DIR}/GENRP_fieldmap_g4sbs_friendly_coordinate_system.table SHOW_PROGRESS)
+
   message("Other field maps forthcoming... Anybody know how to get CMake to download files AFTER the configure step, during the build step?")
 
   file(GLOB sbs_field_maps ${CMAKE_CURRENT_BINARY_DIR}/*.table ${CMAKE_CURRENT_BINARY_DIR}/map_696A.dat)

--- a/include/G4SBSEventGen.hh
+++ b/include/G4SBSEventGen.hh
@@ -225,6 +225,9 @@ public:
       fBeamPolDirection *= -1.0;
     }
   }
+
+  void SetTargZoffset( double z ){ fTargZoffset = z; }
+  double GetTargZoffset() const { return fTargZoffset; }
   
   void SetRandomizeTargetSpin( G4bool flag ){ fRandomizeTargetSpin = flag; }
   void SetNumTargetSpinDirections( G4int nspin );
@@ -309,6 +312,8 @@ private:
   double fThMin_had, fThMax_had, fPhMin_had, fPhMax_had; //Angular generation limits for hadron arm 
   double fEhadMin, fEhadMax; //Hadron (total) energy generation limits (for SIDIS case)--Later we will want to add exclusive hadron production.
   double fTargLen, fRasterX, fRasterY, fTargDen; //Targ density is given in atoms or molecules/unit volume
+  double fTargZoffset;
+  
   double fBeamSpotSize;
   double fCircularRasterRadius;
   //double fTargRadLen; //Radiation length of target material, regardless of thickness

--- a/include/G4SBSMessenger.hh
+++ b/include/G4SBSMessenger.hh
@@ -104,6 +104,8 @@ private:
   G4UIcmdWithADoubleAndUnit *rasteryCmd;
   G4UIcmdWithADoubleAndUnit *rasterrCmd;
   G4UIcmdWithADoubleAndUnit *beamspotsizeCmd;
+
+  G4UIcmdWith3VectorAndUnit *TargOffsetCmd; //Offset target position from nominal
   
   //commands controlling pion photoproduction event generation:
   G4UIcmdWithADouble *PionPhoto_tminCmd;

--- a/include/G4SBSTargetBuilder.hh
+++ b/include/G4SBSTargetBuilder.hh
@@ -99,6 +99,10 @@ public:
 
   G4bool UseRad(){return fUseRad;}
   G4double RadZoffset(){return fRadZoffset;}
+
+  G4ThreeVector GetTargPos() const { return fTargPos; }
+  void SetTargPos( G4ThreeVector pos ){ fTargPos = pos; }
+
   
   void BuildRadiator(G4LogicalVolume *, G4RotationMatrix *, G4ThreeVector );
   

--- a/root_macros/PlotSolidAngleMatchGEP.C
+++ b/root_macros/PlotSolidAngleMatchGEP.C
@@ -1,0 +1,239 @@
+#include "TChain.h"
+#include "TTree.h"
+#include "TFile.h"
+#include "TH1D.h"
+#include "TH2D.h"
+
+#include "TCanvas.h"
+#include "TString.h"
+#include "TObjString.h"
+#include "TObjArray.h"
+#include "G4SBSRunData.hh"
+#include "TMath.h"
+
+#include "TVector3.h"
+#include "gep_tree_with_spin.C"
+
+#include <iostream>
+#include <fstream>
+
+void PlotSolidAngleMatchGEP( const char *rootfilename, const char *outfilename="temp.root", double thresh_ECAL=1.5, double thresh_HCAL=0.07 ){
+  TFile *fout = new TFile(outfilename,"RECREATE");
+
+  //We should be able to do this without a config file (read meta-data from root file)
+
+  TChain *C = new TChain("T");
+  C->Add(rootfilename);
+
+  gep_tree_with_spin *T = new gep_tree_with_spin(C);
+
+  //Histograms!
+
+  TH1D *hE_ECAL = new TH1D("hE_ECAL","All events; ECAL energy dep (GeV);",300,0,6.0);
+  TH1D *hE_ECAL_pcut = new TH1D("hE_ECAL_pcut", "Proton arm cut; ECAL energy dep (GeV);",300,0.0,6.0);
+  TH1D *hE_ECAL_panticut = new TH1D("hE_ECAL_panticut", "Proton arm anticut; ECAL energy dep (GeV)", 300,0,6);
+
+  TH1D *hQ2 = new TH1D("hQ2", "All events; Q^{2} (GeV^{2});",300,0,15.0);
+  TH1D *hQ2cutp = new TH1D("hQ2cutp", "Proton arm cuts; Q^{2} (GeV^{2});",300,0,15.0);
+  TH1D *hQ2cute = new TH1D("hQ2cute", "Electron arm cuts; Q^{2} (GeV^{2});",300,0,15.0);
+  TH1D *hQ2cutep = new TH1D("hQ2cutep", "E+P cuts; Q^{2} (GeV^{2});",300,0,15.0);
+
+  TH2D *hECALxy = new TH2D("hECALxy", "All events; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_cutp = new TH2D("hECALxy_cutp", "Proton arm cuts; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_acutp = new TH2D("hECALxy_acutp", "Proton arm anticuts; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_cute = new TH2D("hECALxy_cute", "Electron arm cuts; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_acute = new TH2D("hECALxy_acute", "Electron arm anticuts; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_cutep = new TH2D("hECALxy_cutep", "E+P arm cuts; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_cute_acutp = new TH2D("hECALxy_cute_acutp", "E+!P; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+  TH2D *hECALxy_cutp_acute = new TH2D("hECALxy_cutp_acute", "P+!E; ECAL y projected (m); ECAL x projected (m)", 150,-0.75,0.75, 300, -1.5,1.5);
+
+  TH1D *hECALx = new TH1D("hECALx", "All events; ECAL x projected (m);", 300,-1.5,1.5);
+  TH1D *hECALx_cute = new TH1D("hECALx_cute", "E arm cut; ECAL x projected (m);", 300,-1.5,1.5);
+  TH1D *hECALx_acute = new TH1D("hECALx_acute", "E arm anticut; ECAL x projected (m);", 300,-1.5,1.5);
+  TH1D *hECALx_cutp = new TH1D("hECALx_cutp", "P arm cut; ECAL x projected (m);", 300,-1.5,1.5);
+  TH1D *hECALx_acutp = new TH1D("hECALx_acutp", "P arm anticut; ECAL x projected (m);", 300,-1.5,1.5);
+  TH1D *hECALx_cutep = new TH1D("hECALx_cutep", "E+P arm cuts; ECAL x projected (m);", 300,-1.5,1.5);
+ 
+  TH1D *hECALy = new TH1D("hECALy", "All events; ECAL y projected (m);", 150,-0.75,0.75);
+  TH1D *hECALy_cute = new TH1D("hECALy_cute", "E arm cut; ECAL y projected (m);", 150,-0.75,0.75);
+  TH1D *hECALy_acute = new TH1D("hECALy_acute", "E arm anticut; ECAL y projected (m);", 150,-0.75,0.75);
+  TH1D *hECALy_cutp = new TH1D("hECALy_cutp", "P arm cut; ECAL y projected (m);", 150,-0.75,0.75);
+  TH1D *hECALy_acutp = new TH1D("hECALy_acutp", "P arm anticut; ECAL y projected (m);", 150,-0.75,0.75);
+  TH1D *hECALy_cutep = new TH1D("hECALy_cutep", "E+P arm cuts; ECAL y projected (m);", 150,-0.75,0.75);
+  
+  //Now we also need 1D and 2D histograms for theta, phi, th vs phi etc for various cuts to set event generation limits
+
+  TH1D *hetheta = new TH1D("hetheta", "All events; #theta_{e} (deg)", 500, 0, 50);
+  TH1D *hetheta_cute = new TH1D("hetheta_cute", "ECAL cut; #theta_{e} (deg)", 500, 0, 50);
+  TH1D *hetheta_anticute = new TH1D("hetheta_anticute", "ECAL anticut; #theta_{e} (deg)", 500, 0, 50);
+  TH1D *hetheta_cutp = new TH1D("hetheta_cutp", "P arm cut; #theta_{e} (deg)", 500, 0, 50);
+  TH1D *hetheta_anticutp = new TH1D("hetheta_anticutp", "P arm anticut; #theta_{e} (deg)", 500, 0, 50);
+  TH1D *hetheta_cutep = new TH1D("hetheta_cutep", "E+P arm cuts; #theta_{e} (deg)", 500, 0, 50);
+  
+  TH1D *hephi = new TH1D("hephi", "All events; #phi_{e} (deg)", 450, -45, 45);
+  TH1D *hephi_cute = new TH1D("hephi_cute", "ECAL cut; #phi_{e} (deg)", 450, -45, 45);
+  TH1D *hephi_anticute = new TH1D("hephi_anticute", "ECAL anticut; #phi_{e} (deg)", 450, -45, 45);
+  TH1D *hephi_cutp = new TH1D("hephi_cutp", "P arm cut; #phi_{e} (deg)", 450, -45, 45);
+  TH1D *hephi_anticutp = new TH1D("hephi_anticutp", "P arm anticut; #phi_{e} (deg)", 450, -45, 45);
+  TH1D *hephi_cutep = new TH1D("hephi_cutep", "E+P arm cuts; #phi_{e} (deg)", 450, -45, 45);
+  
+  TH2D *hethph = new TH2D("hethph", "All events; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_cute = new TH2D("hethph_cute", "ECAL cut; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_cutp = new TH2D("hethph_cutp", "P arm cuts; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_cutep = new TH2D("hethph_cutep", "E+P arm cuts; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_anticute = new TH2D("hethph_anticute", "ECAL anticut; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_anticutp = new TH2D("hethph_anticutp", "P arm anticuts; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+
+  TH2D *hethph_cute_acutp = new TH2D("hethph_cute_acutp", "ECAL cut; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  TH2D *hethph_cutp_acute = new TH2D("hethph_cutp_acute", "P arm cuts; #theta_{e} (deg); #phi_{e} (deg)", 250, 0, 50, 225, -45, 45 );
+  
+  double ECALdist=5.0, ECALtheta=36.1*TMath::DegToRad();
+  double SBSdist=1.6, SBStheta=28.5;
+  double HCALdist=10.0;
+  double Ebeam=4.359;
+
+  long nevent=0;
+
+  int treenum=-1, oldtreenum=-1;
+  
+  while(C->GetEntry(nevent++) ){
+    if( nevent%1000 == 0 ) cout << nevent << endl;
+    
+    treenum = C->GetTreeNumber();
+    if( treenum != oldtreenum ){
+      oldtreenum = treenum;
+      G4SBSRunData *rdtemp;
+      TFile *ftemp = C->GetFile();
+
+      ftemp->GetObject( "run_data", rdtemp );
+      if( rdtemp ){ //read relevant parameters from file:
+	ECALdist = rdtemp->fBBdist;
+	ECALtheta = rdtemp->fBBtheta;
+	SBSdist = rdtemp->fSBSdist;
+	SBStheta = rdtemp->fSBStheta;
+	HCALdist = rdtemp->fHCALdist;
+	Ebeam = rdtemp->fBeamE;
+      }
+    }
+
+    bool FTtrack = false, FPPtrack = false, HCALcut = false, ECALcut = false;
+    HCALcut = T->Harm_HCalScint_det_esum>thresh_HCAL;
+    ECALcut = T->Earm_ECalTF1_det_esum>thresh_ECAL;
+
+    for( int itr=0; itr<T->Harm_FT_Track_ntracks; itr++ ){
+      if( T->Harm_FT_Track_MID->at(itr) == 0 ) FTtrack = true;
+    }
+    for( int itr=0; itr<T->Harm_FPP1_Track_ntracks; itr++ ){
+      if( T->Harm_FPP1_Track_MID->at(itr) == 0 ) FPPtrack = true;
+    }
+
+    hE_ECAL->Fill( T->Earm_ECalTF1_det_esum );
+    bool pcut = FTtrack && FPPtrack && HCALcut;
+    if( pcut ) {
+      hE_ECAL_pcut->Fill( T->Earm_ECalTF1_det_esum );
+    } else {
+      hE_ECAL_panticut->Fill( T->Earm_ECalTF1_det_esum );
+    }
+
+    hetheta->Fill( T->ev_th*TMath::RadToDeg() );
+    hephi->Fill( T->ev_ph*TMath::RadToDeg() );
+    hethph->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+
+    if( ECALcut ){
+      hetheta_cute->Fill( T->ev_th*TMath::RadToDeg() );
+      hephi_cute->Fill( T->ev_ph*TMath::RadToDeg() );
+      hethph_cute->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+      if( pcut ){
+	hetheta_cutep->Fill( T->ev_th*TMath::RadToDeg() );
+	hephi_cutep->Fill( T->ev_ph*TMath::RadToDeg() );
+	hethph_cutep->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+      } else {
+	hethph_cute_acutp->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+      }
+      
+    } else {
+      hetheta_anticute->Fill( T->ev_th*TMath::RadToDeg() );
+      hephi_anticute->Fill( T->ev_ph*TMath::RadToDeg() );
+      hethph_anticute->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+      if( pcut ){
+	hethph_cutp_acute->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+      }
+    }
+
+    if( pcut ){
+      hetheta_cutp->Fill( T->ev_th*TMath::RadToDeg() );
+      hephi_cutp->Fill( T->ev_ph*TMath::RadToDeg() );
+      hethph_cutp->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+    } else {
+      hetheta_anticutp->Fill( T->ev_th*TMath::RadToDeg() );
+      hephi_anticutp->Fill( T->ev_ph*TMath::RadToDeg() );
+      hethph_anticutp->Fill( T->ev_th*TMath::RadToDeg(), T->ev_ph*TMath::RadToDeg() );
+    }
+    hQ2->Fill( T->ev_Q2 );
+    if( pcut ){
+      hQ2cutp->Fill( T->ev_Q2 );
+    }
+    if( ECALcut ) hQ2cute->Fill( T->ev_Q2 );
+    if( ECALcut && pcut ) hQ2cutep->Fill( T->ev_Q2 );
+
+    TVector3 ehat( sin( T->ev_th ) * cos( T->ev_ph ),
+		   sin( T->ev_th ) * sin( T->ev_ph ),
+		   cos( T->ev_th ) );
+
+    TVector3 ECALzaxis(sin(ECALtheta), 0, cos(ECALtheta) );
+    TVector3 ECALxaxis(cos(ECALtheta), 0, -sin(ECALtheta) );
+    TVector3 ECALyaxis(0,1,0);
+
+    TVector3 ECAL_origin = ECALdist * ECALzaxis;
+
+    TVector3 vertex(T->ev_vx, T->ev_vy, T->ev_vz );
+
+    double sint = (ECAL_origin - vertex).Dot( ECALzaxis ) / (ehat.Dot(ECALzaxis) );
+
+    TVector3 intersect = vertex + sint * ehat;
+    
+    double xECAL = (intersect - ECAL_origin).Dot( ECALxaxis );
+    double yECAL = (intersect - ECAL_origin).Dot( ECALyaxis );
+
+    hECALx->Fill( yECAL );
+    hECALy->Fill( xECAL );
+    hECALxy->Fill( xECAL, yECAL );
+    if( pcut ){
+      hECALxy_cutp->Fill( xECAL, yECAL );
+      hECALx_cutp->Fill( yECAL );
+      hECALy_cutp->Fill( xECAL );
+    } else {
+      hECALxy_acutp->Fill( xECAL, yECAL );
+      hECALx_acutp->Fill( yECAL );
+      hECALy_acutp->Fill( xECAL );
+    }
+
+    if( ECALcut ){
+      hECALxy_cute->Fill( xECAL, yECAL );
+      hECALx_cute->Fill( yECAL );
+      hECALy_cute->Fill( xECAL );
+    } else {
+      hECALxy_acute->Fill( xECAL, yECAL );
+      hECALx_acute->Fill( yECAL );
+      hECALy_acute->Fill( xECAL );
+    };
+
+    if( ECALcut && pcut ){
+      hECALxy_cutep->Fill( xECAL, yECAL );
+      hECALx_cutep->Fill( yECAL );
+      hECALy_cutep->Fill( xECAL );
+    }
+
+    if( ECALcut && !pcut ){
+      hECALxy_cute_acutp->Fill( xECAL, yECAL );
+    }
+
+    if( pcut && !ECALcut ){
+      hECALxy_cutp_acute->Fill( xECAL, yECAL );
+    }
+      
+    
+  }
+
+  fout->Write();
+}

--- a/scripts/GEP0.mac
+++ b/scripts/GEP0.mac
@@ -1,5 +1,5 @@
 ## Configure G4SBS for gep (Q^2 = 5.7 GeV^2, 3rd pass)
-/g4sbs/filename        GEP0_elastic_rsamp_test.root   ## Output rootfile
+/g4sbs/filename        GEP0c_rsamp_test2.root   ## Output rootfile
 
 ## Configure Experiment
 /g4sbs/exp             gep
@@ -12,24 +12,24 @@
 /g4sbs/kine            elastic          ## Generator
 /g4sbs/runtime         1.0 s
 /g4sbs/beamcur         50.0 microampere
-/g4sbs/rasterx         4.0 mm
-/g4sbs/rastery         4.0 mm
-/g4sbs/beamE           4.3 GeV
+/g4sbs/rasterx         2.0 mm
+/g4sbs/rastery         2.0 mm
+/g4sbs/beamE           4.359 GeV
 /g4sbs/thmin           29.0 deg
-/g4sbs/thmax           42.0 deg
-/g4sbs/phmin           -25.0 deg
-/g4sbs/phmax           25.0 deg
+/g4sbs/thmax           45.0 deg
+/g4sbs/phmin           -32.0 deg
+/g4sbs/phmax           32.0 deg
 
 /g4sbs/eemin 	       0.5 GeV
 /g4sbs/eemax 	       4.3 GeV
 
-/g4sbs/hadron pi0
-/g4sbs/hphmin -25.0 deg
-/g4sbs/hphmax  25.0 deg
-/g4sbs/hthmin 29.0 deg
-/g4sbs/hthmax 42.0 deg
-/g4sbs/ehmin 0.5 GeV
-/g4sbs/ehmax 4.3 GeV
+#/g4sbs/hadron pi0
+#/g4sbs/hphmin -25.0 deg
+#/g4sbs/hphmax  25.0 deg
+#/g4sbs/hthmin 29.0 deg
+#/g4sbs/hthmax 42.0 deg
+#/g4sbs/ehmin 0.5 GeV
+#/g4sbs/ehmax 4.3 GeV
 
 ## Configure standard detector settings
 /g4sbs/gemres          0.070 mm
@@ -46,7 +46,7 @@
 # assume 2.4 T*m / 1.22 m = 1.97 Tesla
 #/g4sbs/sbsmagfield     1.97 tesla
 #/g4sbs/48d48field      1
-/g4sbs/bbang           35.0 deg
+/g4sbs/bbang           36.1 deg
 /g4sbs/bbdist          5.0 m
 /g4sbs/sbsang          28.5 deg
 /g4sbs/48D48dist       1.6 m
@@ -76,4 +76,4 @@
 /g4sbs/rejectionsampling 1 1000000
 
 ## Run 100 events
-/g4sbs/run             1000
+/g4sbs/run             100

--- a/scripts/vis_GEP0.mac
+++ b/scripts/vis_GEP0.mac
@@ -1,5 +1,5 @@
 ## Configure G4SBS for gep (Q^2 = 5.7 GeV^2, 3rd pass)
-/g4sbs/filename        GEP0_elastic.root   ## Output rootfile
+/g4sbs/filename       vis_GEP0_test.root   ## Output rootfile
 
 ## Configure Experiment
 /g4sbs/exp             gep
@@ -9,16 +9,27 @@
 /g4sbs/targlen         30.0 cm           ## Target Length
 
 ## Configure generator settings
-/g4sbs/kine            elastic           ## Generator
+/g4sbs/kine            elastic          ## Generator
 /g4sbs/runtime         1.0 s
 /g4sbs/beamcur         50.0 microampere
-/g4sbs/rasterx         4.0 mm
-/g4sbs/rastery         4.0 mm
-/g4sbs/beamE           4.3 GeV
-/g4sbs/thmin           29.0 deg
-/g4sbs/thmax           42.0 deg
-/g4sbs/phmin           -25.0 deg
-/g4sbs/phmax           25.0 deg
+/g4sbs/rasterx         2.0 mm
+/g4sbs/rastery         2.0 mm
+/g4sbs/beamE           4.359 GeV
+/g4sbs/thmin           25.0 deg
+/g4sbs/thmax           45.0 deg
+/g4sbs/phmin           -40.0 deg
+/g4sbs/phmax           40.0 deg
+
+/g4sbs/eemin 	       0.5 GeV
+/g4sbs/eemax 	       4.3 GeV
+
+#/g4sbs/hadron pi0
+#/g4sbs/hphmin -25.0 deg
+#/g4sbs/hphmax  25.0 deg
+#/g4sbs/hthmin 29.0 deg
+#/g4sbs/hthmax 42.0 deg
+#/g4sbs/ehmin 0.5 GeV
+#/g4sbs/ehmax 4.3 GeV
 
 ## Configure standard detector settings
 /g4sbs/gemres          0.070 mm
@@ -62,10 +73,10 @@
 #/g4sbs/FPP1CH2thick 55 cm
 #/g4sbs/FPP2CH2thick
 
+/g4sbs/rejectionsampling 1 1000000
 
 ## Run 100 events
-#/g4sbs/run             100
-
+#/g4sbs/run             1000
 
 
 # start with wide-open cuts:
@@ -108,10 +119,11 @@
 # Set specific colour for identification : ghost parallel geometry envelope ("ghost") as yellow
 #
 # Specify view angle:
-/vis/viewer/set/viewpointThetaPhi 90 120  deg
+/vis/viewer/set/viewpointThetaPhi 90 60  deg
+/vis/viewer/pan 15 0 m
 #
 # Specify zoom value:
-/vis/viewer/zoom 2.5
+/vis/viewer/zoom 3
 #
 # Specify style (surface or wireframe):
 /vis/viewer/set/style surface

--- a/src/G4SBSHArmBuilder.cc
+++ b/src/G4SBSHArmBuilder.cc
@@ -979,19 +979,21 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
       RearClamp_log->SetVisAttributes(clampVisAtt);
     } // Rear clamp log (GEp)
 
-    G4RotationMatrix *rot_copper = new G4RotationMatrix;
+    // G4RotationMatrix *rot_copper = new G4RotationMatrix;
 
-    rot_copper->rotateY( f48D48ang + 6.0*deg);
+    // rot_copper->rotateY( f48D48ang + 6.0*deg);
 
-    G4Box *copper_shield = new G4Box("copper_shield", (20.0*2.54*cm)/2.0, (20.0*2.54*cm)/2.0, (0.05*cm)/2.0);
+    // G4Box *copper_shield = new G4Box("copper_shield", (20.0*2.54*cm)/2.0, (20.0*2.54*cm)/2.0, (0.05*cm)/2.0);
 
-    G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
+    // G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
 
-    //G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
-    G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
+    // //G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
+    // G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
 
-    new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
+    //new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
 
+
+    
     //Make lead shielding in clamp:
     // G4double angtrap = 10.0*deg;
     // G4double Trap_DZ = 70.0*cm; //length in z

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -356,6 +356,11 @@ G4SBSMessenger::G4SBSMessenger(){
   tgtDiamCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/targdiam",this);
   tgtDiamCmd->SetGuidance("Cryotarget or gas target cell diameter (assumed cylindrical), applies to LH2/LD2/H2/3He");
   tgtDiamCmd->SetParameterName("targdiam", false);
+
+  TargOffsetCmd = new G4UIcmdWith3VectorAndUnit( "/g4sbs/targpos",this );
+  TargOffsetCmd->SetGuidance("Target position offset (relative to nominal)");
+  TargOffsetCmd->SetGuidance("Requires three vector (x,y,z) position in global coordinates and unit");
+  TargOffsetCmd->SetParameterName("tgtx0", "tgty0", "tgtz0", false );
   
   // SchamGasTgtCmd = new G4UIcmdWithAnInteger("/g4sbs/schbrflag",this);
   // SchamGasTgtCmd->SetGuidance("Build evacuated scattering chamber for gas target? (1=yes, 0=no)");
@@ -1745,6 +1750,12 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
     fdetcon->fTargetBuilder->SetTargDiameter(Dcell);
   }
 
+  if( cmd == TargOffsetCmd ){
+    G4ThreeVector pos = TargOffsetCmd->GetNew3VectorValue( newValue );
+    fdetcon->fTargetBuilder->SetTargPos( pos );
+    fevgen->SetTargZoffset( pos.z() );
+  }
+  
   // if( cmd == SchamGasTgtCmd ){
   //   G4int flag = SchamGasTgtCmd->GetNewIntValue( newValue );
   //   fdetcon->fTargetBuilder->SetSchamFlag( flag );

--- a/src/G4SBSRunAction.cc
+++ b/src/G4SBSRunAction.cc
@@ -68,7 +68,7 @@ void G4SBSRunAction::EndOfRunAction(const G4Run* aRun)
   G4cout << "Elapsed time = " << timer->GetRealElapsed() << G4endl;
   G4cout << *timer << G4endl;
 
-  G4cout << "simulation rate = " << double(Ntries)/timer->GetRealElapsed() << " events/s" << G4endl;
+  G4cout << "simulation rate = " << double(aRun->GetNumberOfEvent())/timer->GetRealElapsed() << " events/s" << G4endl;
   
   G4SBSRun::GetRun()->GetData()->SetNtries( Ntries );
 

--- a/src/G4SBSTargetBuilder.cc
+++ b/src/G4SBSTargetBuilder.cc
@@ -70,7 +70,7 @@ G4SBSTargetBuilder::G4SBSTargetBuilder(G4SBSDetectorConstruction *dc):G4SBSCompo
   fHadronFilterMaterial = G4String("Aluminum");
 
 
-  fUseHadronFilter = true;
+  fUseHadronFilter = false;
 }
 
 G4SBSTargetBuilder::~G4SBSTargetBuilder(){;}
@@ -1330,9 +1330,11 @@ void G4SBSTargetBuilder::BuildGEpScatCham(G4LogicalVolume *worldlog ){
   
   rot_temp = new G4RotationMatrix;
   rot_temp->rotateX( -90.0*deg );
+
+  //rotation about X by -90 degrees sends 
   
   //Call BuildStandardCryoTarget HERE !
-  BuildStandardCryoTarget(ScatChamber_log, rot_temp, G4ThreeVector(0, -TargetCenter_zoffset, 0));
+  BuildStandardCryoTarget(ScatChamber_log, rot_temp, G4ThreeVector(fTargPos.x(), -(TargetCenter_zoffset+fTargPos.z()), fTargPos.y()));
 
   //Also call BuildHadronFilter here:
   


### PR DESCRIPTION
Several minor, but important updates:

1. Commented out incorrect placement of "copper shield" geometry with respect to GEP vacuum snout
2. Corrected inconsistent mixing of lab-frame and rest-frame electron kinematic variables in cross section calculation for inelastic generator.
3. Added a utility macro to generate useful plots for GEP solid-angle matching tests
4. Modified "run action" end of run method to use the number of ACTUAL event generations rather than the number of ATTEMPTED event generations in its calculation of the event simulation rate. The latter is what is relevant for planning mass farm submissions of g4sbs jobs. 
4. Added code and user interface command to shift target position from nominal. Implemented "/g4sbs/targpos" command which takes a 3 vector and mandatory unit arguments. Specifying a non-zero target offset modifies the z vertex event generation limits for all event generators. However, in this commit the actual positional offset of the relevant target volume(s) is only implemented for GEP, as GEP is the only experiment for which such an offset is potentially relevant. The purpose here is to evaluate the impact of the current GEP target design on the experiment productivity. 