### PR TITLE
Modifying preshower lead-glass chemical composition and density

### DIFF
--- a/src/G4SBSDetectorConstruction.cc
+++ b/src/G4SBSDetectorConstruction.cc
@@ -1277,6 +1277,7 @@ void G4SBSDetectorConstruction::ConstructMaterials(){
   G4Element* elPb = man->FindOrBuildElement("Pb");
   G4Element* elBe = man->FindOrBuildElement("Be");
   G4Element* elW = man->FindOrBuildElement("W");
+  G4Element* elCe = man->FindOrBuildElement("Ce");
   
   G4Material* Titanium = man->FindOrBuildMaterial("G4_Ti");
   fMaterialsMap["Titanium"] = Titanium;
@@ -1290,6 +1291,11 @@ void G4SBSDetectorConstruction::ConstructMaterials(){
   PbO->AddElement(elO, 1);
   fMaterialsMap["TF1_PbO"] = PbO;
 
+  G4Material* Pb3O4 = new G4Material("F101_Pb3O4", bigden, 2);
+  Pb3O4->AddElement(elPb, 3);
+  Pb3O4->AddElement(elO, 4);
+  fMaterialsMap["F101_Pb3O4"] = Pb3O4;
+
   G4Material* K2O = new G4Material("TF1_K2O", bigden, 2);
   K2O->AddElement(elK, 2);
   K2O->AddElement(elO, 1);
@@ -1299,6 +1305,10 @@ void G4SBSDetectorConstruction::ConstructMaterials(){
   As2O3->AddElement(elAs, 2);
   As2O3->AddElement(elO, 3);
   fMaterialsMap["TF1_As2O3"] = As2O3;
+
+  G4Material *Ce = new G4Material("matCe", bigden, 1 );
+  Ce->AddElement(elCe,1);
+  fMaterialsMap["matCe"] = Ce;
   
   // Simulating annealing: http://hallaweb.jlab.org/12GeV/SuperBigBite/SBS-minutes/2014/Sergey_Abrahamyan_LGAnnealing_2014.pdf
   // const G4int nentries_annealing_model=50;
@@ -1517,6 +1527,21 @@ void G4SBSDetectorConstruction::ConstructMaterials(){
   if( fMaterialsListOpticalPhotonDisabled.find( "TF5" ) == fMaterialsListOpticalPhotonDisabled.end() ){
     TF5->SetMaterialPropertiesTable( MPT_temp );
   }
+
+  //Let's also make F101 LG for the BigBite preshower used during SBS:
+  //Density based on Arun's weighing of the preshower blocks:
+  G4Material *F101 = new G4Material("F101", 3.84*g/cm3, 4 );
+
+  F101->AddMaterial( Pb3O4, 0.5123 );
+  F101->AddMaterial( SiO2, 0.4153 );
+  F101->AddMaterial( K2O, 0.07 );
+  F101->AddMaterial( Ce, 0.002 );
+
+  if( fMaterialsListOpticalPhotonDisabled.find( "F101" ) == fMaterialsListOpticalPhotonDisabled.end() ){
+    F101->SetMaterialPropertiesTable( MPT_temp );
+  }
+
+  fMaterialsMap["F101"] = F101; // For BigBite preshower
   fMaterialsMap["TF1"] = TF1; //Default TF1: no temperature increase, no rad. damage.
   fMaterialsMap["TF5"] = TF5;
   fMaterialsMap["TF1_dead"] = TF1_dead;

--- a/src/G4SBSEArmBuilder.cc
+++ b/src/G4SBSEArmBuilder.cc
@@ -1095,7 +1095,7 @@ void G4SBSEArmBuilder::MakeBigBite(G4LogicalVolume *worldlog){
   if(fBBPSOption==0){
     bbpsTF1log = new G4LogicalVolume( bbPSTF1box, GetMaterial("TF5"), "bbpsTF1log" );
   }else{
-    bbpsTF1log = new G4LogicalVolume( bbPSTF1box, GetMaterial("TF1"), "bbpsTF1log" );
+    bbpsTF1log = new G4LogicalVolume( bbPSTF1box, GetMaterial("F101"), "bbpsTF1log" );
   }
   G4cout << "BBPS blocks material is " << bbpsTF1log->GetMaterial()->GetName() << G4endl;
 


### PR DESCRIPTION
Added "F101" material of density 3.84 g/cc to model preshower lead-glass, with slightly different chemical composition compared to the TF1 used for the shower. Same optical properties assumed for now. Density is based on actual measurement by Arun T.  