### PR TITLE
G4SBS ECAL Placement Updates

### DIFF
--- a/include/G4SBSEArmBuilder.hh
+++ b/include/G4SBSEArmBuilder.hh
@@ -50,12 +50,17 @@ public:
   
   void SetGEMfrontend(bool b ){ fBuildGEMfrontend = b; }
 
+  void SetECALVertOffset(double a){fECALVertOffset = a;}
+  void SetECALHorizOffset(double a){fECALHorizOffset = a;}
+
   void MakeHallCGEM(G4LogicalVolume *);
   
   double fBBang;
   double fBBdist;
   double fBBCaldist;
 
+  double fECALVertOffset;
+  double fECALHorizOffset;
   //G4SBSBigBiteField *fbbfield; //Why do we need this in both EArmBuilder and DetectorConstruction?
 
   double fRICHdist; //distance from target of RICH detector

--- a/include/G4SBSECal.hh
+++ b/include/G4SBSECal.hh
@@ -14,6 +14,8 @@ public:
   
   void SetAng(double a){ fAng = a; }
   void SetDist(double a){ fDist= a; }
+  void SetVOff(double a){ fVOff = a; }
+  void SetHOff(double a){ fHOff = a; }
 
   G4LogicalVolume* MakeSuperModule(G4double, G4double, G4double);
   
@@ -26,6 +28,8 @@ public:
 
   double fAng;
   double fDist;
+  double fVOff;
+  double fHOff;
   
 private:
 };

--- a/include/G4SBSMessenger.hh
+++ b/include/G4SBSMessenger.hh
@@ -192,6 +192,9 @@ private:
   G4UIcmdWithAnInteger      *SBSLeadOptionCmd;
   G4UIcmdWithAnInteger      *GENRPAnalyzerOptionCmd;
 
+  G4UIcmdWithADoubleAndUnit *ECALVertOffsetCmd;
+  G4UIcmdWithADoubleAndUnit *ECALHorizOffsetCmd;
+
   G4UIcmdWithADoubleAndUnit  *GEPFPP1_CH2thickCmd;
   G4UIcmdWithADoubleAndUnit  *GEPFPP2_CH2thickCmd;
 

--- a/root_macros/gep_ntuple.h
+++ b/root_macros/gep_ntuple.h
@@ -13,8 +13,9 @@
 #include <TFile.h>
 
 // Header file for the classes stored in the TTree if any.
-#include "c++/v1/vector"
-#include "c++/v1/vector"
+//#include "c++/v1/vector"
+//#include "c++/v1/vector"
+#include <vector>
 
 class gep_ntuple {
 public :

--- a/scripts/vis_gep.mac
+++ b/scripts/vis_gep.mac
@@ -12,11 +12,13 @@
 /g4sbs/kine            elastic           ## Generator
 /g4sbs/runtime         1.0 s
 /g4sbs/beamcur         50.0 microampere
+
 /g4sbs/rasterx         2.0 mm
 /g4sbs/rastery         2.0 mm
 /g4sbs/beamE           10.688 GeV
 /g4sbs/thmin           20.0 deg
 /g4sbs/thmax           42.0 deg
+
 /g4sbs/phmin           -45.0 deg
 /g4sbs/phmax           45.0 deg
 
@@ -28,15 +30,19 @@
 
 ## Configure the magnets
 /g4sbs/bbfield         0
+
 /g4sbs/tosfield        GEP_12map0_newheader.table
 #/g4sbs/tosfield SBSPortableFieldMap_TwoClamps_PoleShims.table 2
 #/g4sbs/scalesbsfield     0.53
+
 # keep default maximum field for now
 # assume 2.4 T*m / 1.22 m = 1.97 Tesla
 #/g4sbs/sbsmagfield     1.97 tesla
 #/g4sbs/48d48field      1
+
 /g4sbs/bbang           29.75 deg
 /g4sbs/bbdist          4.7 m
+
 /g4sbs/sbsang          16.9 deg
 /g4sbs/48D48dist       1.6 m
 
@@ -51,6 +57,12 @@
 # option 1: single-analyzer, 8+8 front and back trackers:
 /g4sbs/gepfppoption 1
 /g4sbs/FPP1CH2thick 55.88 cm
+
+
+/g4sbs/usehadronfilter false
+/g4sbs/leadwallconnect true
+/g4sbs/leadwallthick 0.05 cm
+
 
 # option 2: double-analyzer (both CH2)
 #/g4sbs/gepfppoption 2

--- a/src/G4SBSEArmBuilder.cc
+++ b/src/G4SBSEArmBuilder.cc
@@ -58,6 +58,9 @@ G4SBSEArmBuilder::G4SBSEArmBuilder(G4SBSDetectorConstruction *dc):G4SBSComponent
   fBBang  = 40.0*deg;
   fBBdist = 1.5*m;
 
+  fECALVertOffset = 0.0*cm;
+  fECALHorizOffset = 0.0*cm;
+
   /*
   G4double frontGEM_depth = 20.*cm;
   G4double backGEM_depth = 10.*cm;
@@ -135,7 +138,10 @@ void G4SBSEArmBuilder::BuildComponent(G4LogicalVolume *worldlog){
       G4SBSECal* ECal = new G4SBSECal(fDetCon);
       ECal->SetAng(fBBang);
       ECal->SetDist(fBBdist);
+      ECal->SetVOff(fECALVertOffset);
+      ECal->SetHOff(fECALHorizOffset);
       ECal->BuildComponent(worldlog);
+      
       //MakeBigCal( worldlog );
     }
   if( exptype == G4SBS::kC16 ) 

--- a/src/G4SBSECal.cc
+++ b/src/G4SBSECal.cc
@@ -48,6 +48,8 @@ using namespace std;
 G4SBSECal::G4SBSECal(G4SBSDetectorConstruction *dc):G4SBSComponent(dc){
   fAng = 29.0*deg;
   fDist = 4.9*m;
+  fVOff = 0.0*cm;
+  fHOff = 0.0*cm;
 
   fnzsegments_leadglass_ECAL = 1;
   fnzsegments_leadglass_C16 = 1;
@@ -1271,15 +1273,26 @@ void G4SBSECal::MakeECal_new(G4LogicalVolume *motherlog){
     yfp_start_42[i] = yfp_start_42_default[i] + ECal_hrz_shift;
   }
   */
-  
+  /*
   G4double yfp_start_42[23] = {-58.69*cm, -54.73*cm, -58.69*cm, -54.73*cm, -58.69*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, 
 			       -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -50.81*cm, -58.60*cm,
 			       -54.97*cm, -58.76*cm, -55.13*cm};// from bottom to top
+  */
+  G4double yfp_start_42[23] = {-58.73*cm, -54.61*cm, -58.73*cm, -54.61*cm, -58.73*cm, -52.87*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, 
+			       -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -58.73*cm,
+			       -54.29*cm, -58.73*cm, -54.29*cm};// from bottom to top, make these match center frame measurement from Don Jones, user command shift
+  for(int i = 0; i < 23; i++){
+    yfp_start_42[i] += fHOff;
+  }
 
+
+  //Don Jones gave direct measurements of ECAL and we want to align along the frame center rather than the block center. Oddly enough, the blocks not in the large central cluster(without the horizontal offsets) seem to already match up with the frame center, but the blocks in the large center group should have a y starting pos at -53.0225cm
+
+  
   //xfp and yfp are following the analysis coordinate system, not the same as g4 coord system
   
   //xfpstart based on center of ECal JT model
-  G4double xfpstart = -147.22*cm;
+  G4double xfpstart = -147.22*cm + fVOff;//fVOff
   G4int copy_nb = 0;
   G4double X_block, Y_block;
 
@@ -1795,7 +1808,7 @@ void G4SBSECal::MakeECal_new(G4LogicalVolume *motherlog){
 
   //replace all 40's with 42 here, original 42's placement currently commented out
    
-  G4int SM_num = 0;
+  G4int SM_num = 0; //KIP EDIT HERE FOR 1.25 INCH OFFSET
   X_block = xfpstart+BlockFirst_42;
   for(int i_ = 0; i_<NrowsSM_42*3; i_++){
     Y_block = yfp_start_42[i_/3]+TiWallThick+BlockFirst_42;

--- a/src/G4SBSECal.cc
+++ b/src/G4SBSECal.cc
@@ -1282,9 +1282,10 @@ void G4SBSECal::MakeECal_new(G4LogicalVolume *motherlog){
 			       -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -53.02*cm, -58.73*cm,
 			       -54.29*cm, -58.73*cm, -54.29*cm};// from bottom to top, make these match center frame measurement from Don Jones, user command shift
   for(int i = 0; i < 23; i++){
-    yfp_start_42[i] += fHOff;
+    yfp_start_42[i] += (fHOff + 2.25*2.54*cm); //this, by default, places ecal 2.25 inches closer to the beamline, thus ecal is positioned via its "crystal center"
   }
 
+  //After analyzing the two centering schemes, the crystal center gives very slightly better rate weighted acceptance. This crystal center places ecal 2.25 inches to the right (small angle direction toward beamline) of the frame center which is what the yfp_start_42 defines.
 
   //Don Jones gave direct measurements of ECAL and we want to align along the frame center rather than the block center. Oddly enough, the blocks not in the large central cluster(without the horizontal offsets) seem to already match up with the frame center, but the blocks in the large center group should have a y starting pos at -53.0225cm
 

--- a/src/G4SBSHArmBuilder.cc
+++ b/src/G4SBSHArmBuilder.cc
@@ -978,21 +978,21 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
 
       RearClamp_log->SetVisAttributes(clampVisAtt);
     } // Rear clamp log (GEp)
-
+    /*
     G4RotationMatrix *rot_copper = new G4RotationMatrix;
 
+    rot_copper->rotateY( 17.0*deg + 4.4*deg);
 
-    rot_copper->rotateY( f48D48ang + 4.0*deg);
+    G4Box *copper_shield = new G4Box("copper_shield", (22.0*2.54*cm)/2.0, (22.0*2.54*cm)/2.0, (2.54*cm)/2.0);
 
-    G4Box *copper_shield = new G4Box("copper_shield", (22.0*2.54*cm)/2.0, (22.0*2.54*cm)/2.0, fLeadWallThick/2.0);
+    G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
 
-     G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
-
-     G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
-     G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
-
-     new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
-
+    //G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
+    //G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
+    G4ThreeVector copper_shield_pos(-50.0*cm, 0.0, 103.0*cm); 
+    
+    new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
+    */
 
     
     //Make lead shielding in clamp:
@@ -4208,7 +4208,7 @@ void G4SBSHArmBuilder::MakeFPP( G4LogicalVolume *Mother, G4RotationMatrix *rot, 
     
     G4ThreeVector lead_wall4_pos = G4ThreeVector( 23.75*2.54*cm, trkr_yoff[1] - (30.0*cm), trkr_zpos[1] -317.0*cm -6.1*GEM_z_spacing[1] + 60.0*2.54*cm );
     
-    new G4PVPlacement( 0, lead_wall4_pos, lead_wall4_log, "lead_wall4_phys", Mother, false, 0 );
+    //new G4PVPlacement( 0, lead_wall4_pos, lead_wall4_log, "lead_wall4_phys", Mother, false, 0 );
     
     
     

--- a/src/G4SBSHArmBuilder.cc
+++ b/src/G4SBSHArmBuilder.cc
@@ -981,9 +981,10 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
 
     // G4RotationMatrix *rot_copper = new G4RotationMatrix;
 
-    // rot_copper->rotateY( f48D48ang + 6.0*deg);
 
-    // G4Box *copper_shield = new G4Box("copper_shield", (20.0*2.54*cm)/2.0, (20.0*2.54*cm)/2.0, (0.05*cm)/2.0);
+    rot_copper->rotateY( f48D48ang + 4.0*deg);
+
+    G4Box *copper_shield = new G4Box("copper_shield", (22.0*2.54*cm)/2.0, (22.0*2.54*cm)/2.0, fLeadWallThick/2.0);
 
     // G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
 
@@ -1109,6 +1110,10 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
 
       G4Box *MagnetCutoutLeadBackCover = new G4Box( "MagnetCutoutLeadBackCover", (9.5*2.54*0.5)*cm, (12.0*2.54*0.5)*cm, (4.0*2.54*0.5)*cm );
 
+      G4Box *MagnetCutoutLeadFill = new G4Box( "MagnetCutoutLeadFill", (8.0*2.54*0.5)*cm, (10.8*2.54*0.5)*cm, (4.0*2.54*0.5)*cm );
+ 
+      G4LogicalVolume *MagnetCutoutLeadFill_log = new G4LogicalVolume( MagnetCutoutLeadFill, GetMaterial("Lead"), "MagnetCutoutLeadFill_log" );					       
+
 
       G4LogicalVolume *FrontClampLeadInsert_log = new G4LogicalVolume( FrontClampLeadInsert, GetMaterial("Lead"), "FrontClampLeadInsert_log" );
 
@@ -1135,6 +1140,8 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
       G4ThreeVector posrel_backleadinsert(23.0*2.54*cm, 0, f48D48dist - FrontClamp_zoffset + 210.0*cm + (0*2.54)*cm);
 
       G4ThreeVector posrel_magcutoutlead(23.*2.54*cm, 0, f48D48dist - FrontClamp_zoffset + 170.0*cm + (0*2.54)*cm);
+
+      G4ThreeVector posrel_magcutoutleadfill(23.0*2.54*cm, -0.4*2.54*cm, f48D48dist - FrontClamp_zoffset + 155.0*cm + (0*2.54)*cm);
       
       //f48D48dist - FrontClamp_zoffset
 
@@ -1163,6 +1170,9 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
 
       G4ThreeVector magcutoutlead_pos = (posrel_magcutoutlead.x()) * SBS_xaxis + posrel_magcutoutlead.y() * SBS_yaxis + (posrel_magcutoutlead.z()) * SBS_zaxis;
 
+      G4ThreeVector magcutoutleadfill_pos = (posrel_magcutoutleadfill.x()) * SBS_xaxis + posrel_magcutoutleadfill.y() * SBS_yaxis + (posrel_magcutoutleadfill.z()) * SBS_zaxis;
+
+      
       // if(fUseExtensionLeadInsert == true){
       G4ThreeVector FrontClampLeadInsertAdd_pos( FrontClampLeadInsert_pos.x() - (3.25*2.54)*cm + (0.55*2.54)*cm + fLeadInsertLeftOffset, FrontClampLeadInsert_pos.y(), FrontClampLeadInsert_pos.z() + FCLIdefzdim*0.5 + FCLIadd1zdim*0.5+ fLeadInsertUpstreamOffset);
       G4ThreeVector FrontClampLeadInsertAdd2_pos( FrontClampLeadInsert_pos.x() - (3.25*2.54)*cm + (0.55*2.54)*cm + fLeadInsertLeftOffset + (0.65*2.54)*cm + (0.325*2.54)*cm , FrontClampLeadInsert_pos.y(), FrontClampLeadInsert_pos.z() + FCLIdefzdim*0.5 + FCLIadd2zdim*0.5 + fLeadInsertUpstreamOffset);
@@ -1182,7 +1192,10 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
       //new G4PVPlacement( rot_lead, FrontClampLeadInsertAdd_pos, FrontClampLeadInsertAdd_log, "FrontClampLeadInsertAdd_phys", motherlog, false, 0, false );
       //new G4PVPlacement( rot_lead, FrontClampLeadInsertAdd2_pos, FrontClampLeadInsertAdd2_log, "FrontClampLeadInsertAdd2_phys", motherlog, false, 0, false );
 
-      new G4PVPlacement( rot_lead_cutout, magcutoutlead_pos, MagnetCutoutLeadBackCover_log, "MagnetCutoutLeadBackCover_phys", motherlog, false, 0, false );
+
+      //new G4PVPlacement( rot_lead_cutout, magcutoutlead_pos, MagnetCutoutLeadBackCover_log, "MagnetCutoutLeadBackCover_phys", motherlog, false, 0, false );
+      
+      new G4PVPlacement( rot_lead_cutout, magcutoutleadfill_pos, MagnetCutoutLeadFill_log, "MagnetCutoutLeadFill_phys", motherlog, false, 0, false );
       
       //new G4PVPlacement( rot_lead, FrontClampLeadInsertTrap_pos, FrontClampLeadInsertTrap_log, "FrontClampLeadInsertTrap_phys", motherlog, false, 0, false );
 
@@ -4106,11 +4119,26 @@ void G4SBSHArmBuilder::MakeFPP( G4LogicalVolume *Mother, G4RotationMatrix *rot, 
 
   //ft shield wall
 
-  fLeadWallThick = 10.16*cm;
+  double fLeadWallThick1 = 10.16*cm;
   //fUseLeadWallConnected = false;
   fUseOldLeadWall = false;
 
   if(fUseOldLeadWall == false){
+
+    G4double RearClamp_width = 105.12*2.54*cm;
+    G4double RearClamp_height = 114.96*2.54*cm;
+    G4double RearClamp_depth = 5.91*2.54*cm;
+    
+    G4Box *RearClamp_Box = new G4Box("RearClamp_Box", RearClamp_width/2.0, RearClamp_height/2.0, RearClamp_depth/2.0 );
+    
+    G4double RearClamp_GapWidth = 18.11*2.54*cm;
+    G4double RearClamp_GapHeight = 51.18*2.54*cm;
+    G4double RearClamp_NotchWidth = 37.84*2.54*cm;
+    G4double RearClamp_NotchHeight = 39.37*2.54*cm;
+
+    G4double RearClamp_zoffset = 11.43*2.54*cm + RearClamp_depth/2.0; 
+    G4double RearClamp_xoffset = -f48D48width/2.0 + RearClamp_width/2.0; 
+    G4double RearClamp_r = f48D48dist + f48D48depth + RearClamp_zoffset;
 
     G4RotationMatrix *rot_lead_wall = new G4RotationMatrix;
     //G4RotationMatrix *rot_lead_cutout = new G4RotationMatrix;
@@ -4120,13 +4148,18 @@ void G4SBSHArmBuilder::MakeFPP( G4LogicalVolume *Mother, G4RotationMatrix *rot, 
     //G4Box *lead_wall2 = new G4Box("lead_wall2", fLeadWallThick/2.0, 160.0*cm/2.0, GEM_z_spacing[0]*9.0/2.0 );
     //was 11.5 in z
 
-    G4Box *lead_wall2 = new G4Box("lead_wall2", fLeadWallThick/2.0, (64.0*2.54*cm)/2.0, (60.0*2.54*cm)/2.0 );
+    G4Box *lead_wall2 = new G4Box("lead_wall2", fLeadWallThick1/4.0, (64.0*2.54*cm)/2.0, (60.0*2.54*cm)/2.0 );
 
     G4LogicalVolume *lead_wall2_log = new G4LogicalVolume( lead_wall2, GetMaterial("Lead"), "lead_wall2_log" );
 
     //G4ThreeVector lead_wall2_pos = G4ThreeVector( 36.0*cm, trkr_yoff[0], -78.0*cm -3.5*GEM_z_spacing[0]  );
 
-    G4ThreeVector lead_wall2_pos = G4ThreeVector( 34.5*2.54*cm, trkr_yoff[0] - (00.0*cm), -68.5*cm -1.9*GEM_z_spacing[0]  );
+    //RearClamp_r*cos(f48D48ang) + RearClamp_xoffset * sin(f48D48ang) rear clamp zpos
+
+    G4ThreeVector lead_wall2_pos = G4ThreeVector( 35.5*2.54*cm, trkr_yoff[0] - (00.0*cm), -68.5*cm -1.9*GEM_z_spacing[0] + 12.0*2.54*cm );
+    
+
+    
     //was 3.4 gemz
     //x offset was 31.5, testing chris soova model distance
 
@@ -4136,28 +4169,49 @@ void G4SBSHArmBuilder::MakeFPP( G4LogicalVolume *Mother, G4RotationMatrix *rot, 
 
     //G4Box *lead_wall3 = new G4Box("lead_wall3", fLeadWallThick/2.0, 180.0*cm/2.0, GEM_z_spacing[1]*10.0/2.0 );
 
-    G4Box *lead_wall3 = new G4Box("lead_wall3", fLeadWallThick/2.0, (80.0*2.54*cm)/2.0, (60.0*2.54*cm)/2.0 );
+    G4Box *lead_wall3 = new G4Box("lead_wall3", fLeadWallThick1/2.0, (80.0*2.54*cm)/2.0, (60.0*2.54*cm)/2.0 );
     
     G4LogicalVolume *lead_wall3_log = new G4LogicalVolume( lead_wall3, GetMaterial("Lead"), "lead_wall3_log" );
 
-    G4ThreeVector lead_wall3_pos = G4ThreeVector( 34.5*2.54*cm, trkr_yoff[1] - (00.0*cm), trkr_zpos[1] -75.0*cm -7.5*GEM_z_spacing[1] );
+    G4ThreeVector lead_wall3_pos = G4ThreeVector( 35.5*2.54*cm, trkr_yoff[1] - (00.0*cm), trkr_zpos[1] -75.0*cm -7.5*GEM_z_spacing[1] + 12.0*2.54*cm);
+
 
     new G4PVPlacement( 0, lead_wall3_pos, lead_wall3_log, "lead_wall3_phys", Mother, false, 0 );
 
     //lead_wall1 is now used as the shielding in the space between the corrector magnet and the lead wall blocking the line of sight between the beamline and the front tracker(lead_wall2)
 
-    //if(fUseLeadWallConnected == true){
+    if(fUseLeadWallConnected == true){
+      G4Box *lead_wall1 = new G4Box("lead_wall1", fLeadWallThick1/4.0, (40.0*2.54*cm)/2.0, (8.0*2.54*cm)/2.0);
+      
+      G4LogicalVolume *lead_wall1_log = new G4LogicalVolume( lead_wall1, GetMaterial("Lead"), "lead_wall1_log" );
+      
+      G4ThreeVector lead_wall1_pos = G4ThreeVector( 32.5*2.54*cm, trkr_yoff[1] - (30.0*cm), trkr_zpos[1] -317.0*cm -6.1*GEM_z_spacing[1] );
+      
+      new G4PVPlacement( rot_lead_wall, lead_wall1_pos, lead_wall1_log, "lead_wall1_phys", Mother, false, 0 );
+      
+      
+      
+      
+      G4Box *lead_wall0 = new G4Box("lead_wall0", fLeadWallThick1/4.0, (40.0*2.54*cm)/2.0, (10.0*2.54*cm)/2.0);
+      
+      G4LogicalVolume *lead_wall0_log = new G4LogicalVolume( lead_wall0, GetMaterial("Lead"), "lead_wall0_log" );
+      
+      G4ThreeVector lead_wall0_pos = G4ThreeVector( 34.9*2.54*cm, trkr_yoff[1] - (30.0*cm), trkr_zpos[1] -317.0*cm -6.1*GEM_z_spacing[1] + 8.5*2.54*cm );
+      
+      new G4PVPlacement( rot_lead_wall, lead_wall0_pos, lead_wall0_log, "lead_wall0_phys", Mother, false, 0 );
+      
+    }
 
-    G4Box *lead_wall1 = new G4Box("lead_wall1", fLeadWallThick/2.0, (40.0*2.54*cm)/2.0, (8.0*2.54*cm)/2.0);
+    G4Box *lead_wall4 = new G4Box("lead_wall4", (15.75*2.54*cm)/2.0, (40.0*2.54*cm)/2.0, (4.0*2.54*cm)/2.0);
     
-    G4LogicalVolume *lead_wall1_log = new G4LogicalVolume( lead_wall1, GetMaterial("Lead"), "lead_wall1_log" );
+    G4LogicalVolume *lead_wall4_log = new G4LogicalVolume( lead_wall4, GetMaterial("Lead"), "lead_wall4_log" );
     
-    G4ThreeVector lead_wall1_pos = G4ThreeVector( 34.0*2.54*cm, trkr_yoff[1] - (30.0*cm), trkr_zpos[1] -317.0*cm -6.4*GEM_z_spacing[1] );
+    G4ThreeVector lead_wall4_pos = G4ThreeVector( 23.75*2.54*cm, trkr_yoff[1] - (30.0*cm), trkr_zpos[1] -317.0*cm -6.1*GEM_z_spacing[1] + 60.0*2.54*cm );
     
-    new G4PVPlacement( rot_lead_wall, lead_wall1_pos, lead_wall1_log, "lead_wall1_phys", Mother, false, 0 );
+    new G4PVPlacement( 0, lead_wall4_pos, lead_wall4_log, "lead_wall4_phys", Mother, false, 0 );
     
-      //}
-  
+    
+    
   }
   // int ntracker = 3; //FT, FPP1, FPP2
   // int ngem[3] = {6,5,5};

--- a/src/G4SBSHArmBuilder.cc
+++ b/src/G4SBSHArmBuilder.cc
@@ -979,19 +979,19 @@ void G4SBSHArmBuilder::MakeSBSFieldClamps( G4LogicalVolume *motherlog ){
       RearClamp_log->SetVisAttributes(clampVisAtt);
     } // Rear clamp log (GEp)
 
-    // G4RotationMatrix *rot_copper = new G4RotationMatrix;
+    G4RotationMatrix *rot_copper = new G4RotationMatrix;
 
 
     rot_copper->rotateY( f48D48ang + 4.0*deg);
 
     G4Box *copper_shield = new G4Box("copper_shield", (22.0*2.54*cm)/2.0, (22.0*2.54*cm)/2.0, fLeadWallThick/2.0);
 
-    // G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
+     G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
 
-    // //G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
-    // G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
+     G4ThreeVector copper_shield_pos(RearClamp_pos.X(), RearClamp_pos.Y(), RearClamp_pos.Z() - 120.0*cm);
+     G4ThreeVector copper_shield_pos( -FrontClamp_r*sin( f48D48ang ) + FrontClamp_xoffset*cos(f48D48ang) - 7.0*cm, 0.0, FrontClamp_r*cos(f48D48ang) + FrontClamp_xoffset*sin(f48D48ang) - 12.0*cm);
 
-    //new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
+     new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, false );
 
 
     

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -647,6 +647,14 @@ G4SBSMessenger::G4SBSMessenger(){
   SBSLeadOptionCmd->SetGuidance("SBS beamline lead shielding configuration: 0= nope 1=yes");
   SBSLeadOptionCmd->SetParameterName("uselead",false);
 
+  ECALVertOffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/ecalvertoffset",this);
+  ECALVertOffsetCmd->SetGuidance("Vertical offset of ecal");
+  ECALVertOffsetCmd->SetParameterName("ecaloffsetvertical",false);
+
+  ECALHorizOffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/ecalhorizoffset",this);
+  ECALHorizOffsetCmd->SetGuidance("Horizontal offset of ecal relative to frame center alignment");
+  ECALHorizOffsetCmd->SetParameterName("ecaloffsethorizontal",false);
+
   GENRPAnalyzerOptionCmd = new G4UIcmdWithAnInteger("/g4sbs/genrpAnalyzer",this);
   GENRPAnalyzerOptionCmd->SetGuidance("GEnRP Analyzer configuration: 0=none+no beamline PR; 1=none, 2=Cu+Gla(para), 3=Cu+Gla(perp), 4=Cu+CGEN");
   GENRPAnalyzerOptionCmd->SetParameterName("genrpAnalyzer",false);
@@ -2000,6 +2008,16 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
     G4cout << "/g4sbs/richgas invoked, setting RICH gas to " << gasname << G4endl;
     
     fdetcon->fHArmBuilder->SetRICHgas( gasname );
+  }
+
+  if( cmd == ECALVertOffsetCmd ){
+    G4double v = ECALVertOffsetCmd->GetNewDoubleValue(newValue);
+    fdetcon->fEArmBuilder->SetECALVertOffset( v );
+  }
+  
+  if( cmd == ECALHorizOffsetCmd ){
+    G4double v = ECALHorizOffsetCmd->GetNewDoubleValue(newValue);
+    fdetcon->fEArmBuilder->SetECALHorizOffset( v );
   }
   
   if( cmd == hcaldistCmd ){

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -652,7 +652,7 @@ G4SBSMessenger::G4SBSMessenger(){
   ECALVertOffsetCmd->SetParameterName("ecaloffsetvertical",false);
 
   ECALHorizOffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/ecalhorizoffset",this);
-  ECALHorizOffsetCmd->SetGuidance("Horizontal offset of ecal relative to frame center alignment");
+  ECALHorizOffsetCmd->SetGuidance("Horizontal offset of ecal relative to crystal center alignment, positive number moves ecal closer to the beamline");
   ECALHorizOffsetCmd->SetParameterName("ecaloffsethorizontal",false);
 
   GENRPAnalyzerOptionCmd = new G4UIcmdWithAnInteger("/g4sbs/genrpAnalyzer",this);

--- a/src/G4SBSTargetBuilder.cc
+++ b/src/G4SBSTargetBuilder.cc
@@ -707,7 +707,7 @@ void G4SBSTargetBuilder::BuildStandardScatCham(G4LogicalVolume *worldlog ){
   				  0,
   				  SCRightSnoutWindowFrameDist*cos(SCRightSnoutAngle)), 
   		    logicScatChamberRightSnoutWindowFrame, "SCRightSnoutWindowFrame", worldlog, false, 0, ChkOverlaps);
-  
+
 
   if( fPlasticPlate ){
     G4Box* solidPlasticPlate = 
@@ -1310,6 +1310,22 @@ void G4SBSTargetBuilder::BuildGEpScatCham(G4LogicalVolume *worldlog ){
     G4ThreeVector EarmCutout_pos_global = Snout_position_global + FrontLeftCorner_pos_local - Snout_Thick/2.0 * Earm_zaxis + (SnoutEarmPlate_Width/2.0 + SnoutEarmWindow_xcenter) * Earm_xaxis;
 
     new G4PVPlacement( rot_earm_window, EarmCutout_pos_global, SnoutEarmWindowCutout_log, "SnoutEarmWindowCutout_phys", worldlog, false, 0 );
+
+
+
+    G4RotationMatrix *rot_copper = new G4RotationMatrix;
+
+    rot_copper->rotateY( 17.0*deg + 4.4*deg);
+
+    G4Box *copper_shield = new G4Box("copper_shield", (22.0*2.54*cm)/2.0, (22.0*2.54*cm)/2.0, (2.54*cm)/2.0);
+
+    G4LogicalVolume *copper_shield_log = new G4LogicalVolume( copper_shield, GetMaterial("Copper"), "copper_shield_log" );
+
+    //new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", motherlog, false, 0, fals
+    
+    G4ThreeVector copper_shield_pos( (HarmCutout_pos_global.getX() + 2.0*cm), HarmCutout_pos_global.getY(), (HarmCutout_pos_global.getZ() + 7.0*cm) ); 
+
+    new G4PVPlacement( rot_copper, copper_shield_pos, copper_shield_log, "copper_shield_phys", worldlog, false, 0 );
   }
   //What's next? Define scattering chamber vacuum volume:
   G4double ScatChamberRadius = 23.80*inch;


### PR DESCRIPTION
ECal is now positioned along its "crystal center" by default, which places ecal 2.25inches towards the beamline relative to the original frame center. The user command for offsetting ecal is now more clear and the horizontal offset given by the user is now relative to the "crystal center placement". Also the copper shield blocking the HArm snout window is positioned without any dependence upon the actual HArm angle and is strictly always infront of the snout window.