### PR TITLE
Corrected ECAL position, user command for shifting ecal horizontally …

### DIFF
--- a/src/G4SBSEArmBuilder.cc
+++ b/src/G4SBSEArmBuilder.cc
@@ -59,7 +59,7 @@ G4SBSEArmBuilder::G4SBSEArmBuilder(G4SBSDetectorConstruction *dc):G4SBSComponent
   fBBdist = 1.5*m;
 
   fECALVertOffset = 0.0*cm;
-  fECALHorizOffset = 0.0*cm;
+  fECALHorizOffset = -2.25*2.54*cm; //shifting the ecal to be positioned along crystal center
 
   /*
   G4double frontGEM_depth = 20.*cm;

--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -648,11 +648,11 @@ G4SBSMessenger::G4SBSMessenger(){
   SBSLeadOptionCmd->SetParameterName("uselead",false);
 
   ECALVertOffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/ecalvertoffset",this);
-  ECALVertOffsetCmd->SetGuidance("Vertical offset of ecal");
+  ECALVertOffsetCmd->SetGuidance("Vertical offset of ecal, positive number moves ecal upwards");
   ECALVertOffsetCmd->SetParameterName("ecaloffsetvertical",false);
 
   ECALHorizOffsetCmd = new G4UIcmdWithADoubleAndUnit("/g4sbs/ecalhorizoffset",this);
-  ECALHorizOffsetCmd->SetGuidance("Horizontal offset of ecal relative to crystal center alignment, positive number moves ecal closer to the beamline");
+  ECALHorizOffsetCmd->SetGuidance("Horizontal offset of ecal relative to frame center alignment, negative number moves ecal closer to the beamline, this is -2.25inches by default in order to place ecal along its crystal center");
   ECALHorizOffsetCmd->SetParameterName("ecaloffsethorizontal",false);
 
   GENRPAnalyzerOptionCmd = new G4UIcmdWithAnInteger("/g4sbs/genrpAnalyzer",this);


### PR DESCRIPTION
The ecal horizontal shift from the user command now moves the entire EArm volume rather than just the supermodules and lead glass, and the shift is now relative to the frame center, but the default shift value is -2.25inches meaning that by default ecal is positioned along the crystal center. This has been made more clear in the messenger guidance as well.