### PR TITLE
fixing gitinfo.hh problems, again

### DIFF
--- a/pullgitinfo.py
+++ b/pullgitinfo.py
@@ -5,7 +5,7 @@ presentcwd = os.getcwd()
 os.chdir(sys.argv[1])
 
 
-f = os.popen("git log -n 1 && git status -bs && echo \"\nGeant4 version\" `geant4-config --version` && echo \"  ROOT version\" `root-config --version` && echo \" `cmake --version`\" && echo \"\nGenerated at `date`\"")
+f = os.popen("git log -n 1 --pretty=oneline && git status -bs && echo \"\nGeant4 version\" `geant4-config --version` && echo \"  ROOT version\" `root-config --version` && echo \" `cmake --version`\" && echo \"\nGenerated at `date`\"")
 
 boringstring = "";
 fullstring = "";

--- a/pullgitinfo3.py
+++ b/pullgitinfo3.py
@@ -27,7 +27,7 @@ if  len(boringstring) > maxlen:
      boringstring = boringstring[0:maxlen-1]
 
 for x in boringstring:
-    fullstring += '\\x'+x.encode('utf-8').hex()
+    fullstring += '\\x'+x.encode(encoding="utf-8",errors="strict").hex()
 
      
 

--- a/pullgitinfo3.py
+++ b/pullgitinfo3.py
@@ -6,7 +6,7 @@ presentcwd = os.getcwd()
 os.chdir(sys.argv[1])
 
 
-f = os.popen("git log -n 1 && git status -bs && echo \"\nGeant4 version\" `geant4-config --version` && echo \"  ROOT version\" `root-config --version` && echo \" `cmake --version`\" && echo \"\nGenerated at `date`\"")
+f = os.popen("git log -n 1 --pretty=oneline && git status -bs && echo \"\nGeant4 version\" `geant4-config --version` && echo \"  ROOT version\" `root-config --version` && echo \" `cmake --version`\" && echo \"\nGenerated at `date`\"")
 
 boringstring = "";
 fullstring = "";


### PR DESCRIPTION
added oneline formatting option to the git log command in pullgitinfo(3).py to try to prevent nasty hex encoding errors in the gitinfo.hh file