### PR TITLE
Reversing the addition of /g4sbs/firstevent command for SIMC 

### DIFF
--- a/src/G4SBSMessenger.cc
+++ b/src/G4SBSMessenger.cc
@@ -1038,15 +1038,15 @@ void G4SBSMessenger::SetNewValue(G4UIcommand* cmd, G4String newValue){
       fevgen->InitializePythia6_Tree();
     }
     if( fevgen->GetKine() == G4SBS::kSIMC ){
-      //Also allow for starting at a different entry than zero in the SIMC chain:
-      long firstevt = fevgen->GetFirstEvent();
+      // //Also allow for starting at a different entry than zero in the SIMC chain:
+      // long firstevt = fevgen->GetFirstEvent();
 
-      long lastevt_chain = fevgen->GetPythiaChain()->GetEntries()-1;
-      nevt = std::min( long(nevt), lastevt_chain-firstevt + 1 );
+      // long lastevt_chain = fevgen->GetPythiaChain()->GetEntries()-1;
+      // nevt = std::min( long(nevt), lastevt_chain-firstevt + 1 );
       
-      // if( fevgen->GetSIMCChain()->GetEntries() < nevt ){
-      // 	nevt = fevgen->GetSIMCChain()->GetEntries();
-      // }
+      if( fevgen->GetSIMCChain()->GetEntries() < nevt ){
+	nevt = fevgen->GetSIMCChain()->GetEntries();
+      }
       fevgen->InitializeSIMC_Tree();
     }
 


### PR DESCRIPTION
(https://github.com/JeffersonLab/g4sbs/commit/4e9d269f117a519a71d04042566c5bc0517c7c3c#diff-51b1fd196093559e834f41478996786bbbdf8bbbb089fb8b2619dcf19acccf6a). It is breaking the execution! This command is not urgent but useful to have. In future, we should investigate the cause of the crash and fix it.